### PR TITLE
Add LiteMol viewer and secondary structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "file-saver": "^1.3.8",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
+    "litemol": "https://github.com/dsehnal/LiteMol",
     "lodash": "^4.17.11",
     "ot-ui": "^0.0.60",
     "polished": "^2.3.0",

--- a/src/components/ProteinInformation/Detail.js
+++ b/src/components/ProteinInformation/Detail.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import withStyles from '@material-ui/core/styles/withStyles';
 
-import { OtTable } from 'ot-ui';
-
-import LiteMolRenderer from './LiteMolRenderer';
+import Structure from './Structure';
 
 const query = gql`
   query ProteinInfoQuery($ensgId: String!) {
@@ -20,7 +17,7 @@ const query = gql`
           uniprotId
           pdbId
           pdbs {
-            id
+            pdbId
             chain
             start
             end
@@ -43,35 +40,6 @@ const query = gql`
     }
   }
 `;
-
-const columns = [
-  {
-    id: 'id',
-    label: 'PDB ID',
-    renderCell: d => d.id.toUpperCase(),
-  },
-  {
-    id: 'method',
-    label: 'Method',
-  },
-  {
-    id: 'coverage',
-    label: 'Coverage',
-  },
-  {
-    id: 'resolution',
-    label: 'Resolution',
-  },
-  {
-    id: 'chain',
-    label: 'Chain',
-  },
-  {
-    id: 'start',
-    label: 'Position',
-    renderCell: d => `${d.start} - ${d.end}`,
-  },
-];
 
 const styles = () => ({
   keywordCategory: {
@@ -138,21 +106,7 @@ class ProteinInformationModal extends React.Component {
                   <div>Something...</div>
                 ) : null}
                 {value === 'structure' ? (
-                  <div>
-                    <Grid container>
-                      <Grid item xs={12} md={6}>
-                        <LiteMolRenderer pdbId={pdbId} />
-                      </Grid>
-                      <Grid item xs={12} md={6}>
-                        <OtTable
-                          loading={false}
-                          error={null}
-                          columns={columns}
-                          data={pdbs}
-                        />
-                      </Grid>
-                    </Grid>
-                  </div>
+                  <Structure pdbId={pdbId} pdbs={pdbs} />
                 ) : null}
                 {value === 'subCellularLocation' ? (
                   <div>

--- a/src/components/ProteinInformation/Detail.js
+++ b/src/components/ProteinInformation/Detail.js
@@ -35,6 +35,12 @@ const query = gql`
             name
           }
           subUnit
+          structuralFeatures {
+            type
+            start
+            end
+          }
+          sequenceLength
         }
       }
     }
@@ -75,6 +81,8 @@ class ProteinInformationModal extends React.Component {
               keywords,
               subCellularLocations,
               subUnit,
+              structuralFeatures,
+              sequenceLength,
             } = data.target.details.protein;
 
             const keywordsGrouped = keywords.reduce((acc, d) => {
@@ -106,7 +114,9 @@ class ProteinInformationModal extends React.Component {
                   <div>Something...</div>
                 ) : null}
                 {value === 'structure' ? (
-                  <Structure pdbId={pdbId} pdbs={pdbs} />
+                  <Structure
+                    {...{ pdbId, pdbs, structuralFeatures, sequenceLength }}
+                  />
                 ) : null}
                 {value === 'subCellularLocation' ? (
                   <div>

--- a/src/components/ProteinInformation/Detail.js
+++ b/src/components/ProteinInformation/Detail.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
+import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import withStyles from '@material-ui/core/styles/withStyles';
+
+import { OtTable } from 'ot-ui';
+
+import LiteMolRenderer from './LiteMolRenderer';
 
 const query = gql`
   query ProteinInfoQuery($ensgId: String!) {
@@ -14,6 +19,15 @@ const query = gql`
         protein {
           uniprotId
           pdbId
+          pdbs {
+            id
+            chain
+            start
+            end
+            coverage
+            resolution
+            method
+          }
           keywords {
             id
             name
@@ -29,6 +43,35 @@ const query = gql`
     }
   }
 `;
+
+const columns = [
+  {
+    id: 'id',
+    label: 'PDB ID',
+    renderCell: d => d.id.toUpperCase(),
+  },
+  {
+    id: 'method',
+    label: 'Method',
+  },
+  {
+    id: 'coverage',
+    label: 'Coverage',
+  },
+  {
+    id: 'resolution',
+    label: 'Resolution',
+  },
+  {
+    id: 'chain',
+    label: 'Chain',
+  },
+  {
+    id: 'start',
+    label: 'Position',
+    renderCell: d => `${d.start} - ${d.end}`,
+  },
+];
 
 const styles = () => ({
   keywordCategory: {
@@ -60,6 +103,7 @@ class ProteinInformationModal extends React.Component {
             const {
               uniprotId,
               pdbId,
+              pdbs,
               keywords,
               subCellularLocations,
               subUnit,
@@ -93,7 +137,23 @@ class ProteinInformationModal extends React.Component {
                 {value === 'sequenceAnnotation' ? (
                   <div>Something...</div>
                 ) : null}
-                {value === 'structure' ? <div>Something...</div> : null}
+                {value === 'structure' ? (
+                  <div>
+                    <Grid container>
+                      <Grid item xs={12} md={6}>
+                        <LiteMolRenderer pdbId={pdbId} />
+                      </Grid>
+                      <Grid item xs={12} md={6}>
+                        <OtTable
+                          loading={false}
+                          error={null}
+                          columns={columns}
+                          data={pdbs}
+                        />
+                      </Grid>
+                    </Grid>
+                  </div>
+                ) : null}
                 {value === 'subCellularLocation' ? (
                   <div>
                     <ul>

--- a/src/components/ProteinInformation/LiteMolRenderer.js
+++ b/src/components/ProteinInformation/LiteMolRenderer.js
@@ -18,15 +18,28 @@ class LiteMolRenderer extends React.Component {
       url: `https://www.ebi.ac.uk/pdbe/entry-files/download/pdb${pdbId}.ent`,
       format: 'pdb',
     });
+    this.plugin = plugin;
+  }
+  componentDidUpdate(prevProps) {
+    const { pdbId } = this.props;
+    if (prevProps.pdbId !== pdbId) {
+      this.plugin.clear();
+      this.plugin.loadMolecule({
+        id: pdbId,
+        url: `https://www.ebi.ac.uk/pdbe/entry-files/download/pdb${pdbId}.ent`,
+        format: 'pdb',
+      });
+    }
   }
   render() {
     return (
       <div
         id="litemol"
         style={{
-          width: '640px',
-          height: '480px',
-
+          border: '1px solid #E0E0E0',
+          width: '100%',
+          height: '100%',
+          minHeight: '480px',
           position: 'relative',
         }}
       />

--- a/src/components/ProteinInformation/LiteMolRenderer.js
+++ b/src/components/ProteinInformation/LiteMolRenderer.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import LiteMol from 'litemol';
+import 'litemol/dist/css/LiteMol-plugin.css';
+
+class LiteMolRenderer extends React.Component {
+  componentDidMount() {
+    const { pdbId } = this.props;
+    const plugin = LiteMol.Plugin.create({
+      target: '#litemol',
+      viewportBackground: '#fff',
+      layoutState: {
+        hideControls: true,
+        isExpanded: false,
+      },
+    });
+    plugin.loadMolecule({
+      id: pdbId,
+      url: `https://www.ebi.ac.uk/pdbe/entry-files/download/pdb${pdbId}.ent`,
+      format: 'pdb',
+    });
+  }
+  render() {
+    return (
+      <div
+        id="litemol"
+        style={{
+          width: '640px',
+          height: '480px',
+
+          position: 'relative',
+        }}
+      />
+    );
+  }
+}
+
+export default LiteMolRenderer;

--- a/src/components/ProteinInformation/Structure.js
+++ b/src/components/ProteinInformation/Structure.js
@@ -1,5 +1,8 @@
 import React from 'react';
+import classNames from 'classnames';
 import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 import { OtTable } from 'ot-ui';
 
@@ -9,12 +12,21 @@ const columns = (pdbId, handleChangePdbId) => [
   {
     id: 'id',
     label: 'PDB ID',
-    renderCell: d =>
-      d.pdbId === pdbId ? (
-        <strong>{d.pdbId.toUpperCase()}</strong>
-      ) : (
-        d.pdbId.toUpperCase()
-      ),
+    renderCell: d => (
+      <a
+        href={`https://www.ebi.ac.uk/pdbe/entry/pdb/${d.pdbId}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {d.pdbId === pdbId ? (
+          <span style={{ fontSize: '1.1rem', fontWeight: 'bold' }}>
+            {d.pdbId.toUpperCase()}
+          </span>
+        ) : (
+          d.pdbId.toUpperCase()
+        )}
+      </a>
+    ),
   },
   {
     id: 'method',
@@ -39,7 +51,7 @@ const columns = (pdbId, handleChangePdbId) => [
   },
   {
     id: 'view',
-    label: '',
+    label: 'Display',
     renderCell: d => (
       <a href="#" onClick={() => handleChangePdbId(d.pdbId)}>
         View
@@ -47,6 +59,40 @@ const columns = (pdbId, handleChangePdbId) => [
     ),
   },
 ];
+
+const styles = theme => ({
+  secondaryStructure: {
+    height: '1.4em',
+    width: '100%',
+    background: '#f1f1f1',
+  },
+  secondaryStructureFeature: {
+    height: '100%',
+  },
+  secondaryStructureHELIX: {
+    fill: '#89B6F9',
+  },
+  secondaryStructureTURN: {
+    fill: '#EC38A6',
+  },
+  secondaryStructureSTRAND: {
+    fill: '#B0FBA4',
+  },
+  legend: {
+    paddingLeft: '5px',
+    paddingRight: '3px',
+    marginLeft: '9px',
+  },
+  legendHELIX: {
+    borderLeft: '0.5em solid #89B6F9',
+  },
+  legendTURN: {
+    borderLeft: '0.5em solid #EC38A6',
+  },
+  legendSTRAND: {
+    borderLeft: '0.5em solid #B0FBA4',
+  },
+});
 
 class Structure extends React.Component {
   state = {};
@@ -58,6 +104,7 @@ class Structure extends React.Component {
     this.setState({ pdbId });
   };
   render() {
+    const { classes, structuralFeatures, sequenceLength } = this.props;
     const { pdbId, pdbs } = this.state;
     return (
       <div>
@@ -81,10 +128,40 @@ class Structure extends React.Component {
               data={pdbs || []}
             />
           </Grid>
+          <Grid item xs={12}>
+            <Typography variant="h6">Secondary structure</Typography>
+            <svg className={classes.secondaryStructure}>
+              {structuralFeatures.map((d, i) => (
+                <rect
+                  key={i}
+                  className={classNames(
+                    classes.secondaryStructureFeature,
+                    classes[`secondaryStructure${d.type}`]
+                  )}
+                  x={`${(d.start * 100) / sequenceLength}%`}
+                  width={`${((d.end - d.start) * 100) / sequenceLength}%`}
+                />
+              ))}
+            </svg>
+            <Typography>
+              Legend:{' '}
+              <span className={classNames(classes.legend, classes.legendHELIX)}>
+                Helix
+              </span>
+              <span className={classNames(classes.legend, classes.legendTURN)}>
+                Turn
+              </span>
+              <span
+                className={classNames(classes.legend, classes.legendSTRAND)}
+              >
+                Beta strand
+              </span>
+            </Typography>
+          </Grid>
         </Grid>
       </div>
     );
   }
 }
 
-export default Structure;
+export default withStyles(styles)(Structure);

--- a/src/components/ProteinInformation/Structure.js
+++ b/src/components/ProteinInformation/Structure.js
@@ -26,7 +26,7 @@ const columns = (pdbId, handleChangePdbId) => [
   },
   {
     id: 'resolution',
-    label: 'Resolution',
+    label: 'Resolution (Å)',
   },
   {
     id: 'chain',

--- a/src/components/ProteinInformation/Structure.js
+++ b/src/components/ProteinInformation/Structure.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+
+import { OtTable } from 'ot-ui';
+
+import LiteMolRenderer from './LiteMolRenderer';
+
+const columns = (pdbId, handleChangePdbId) => [
+  {
+    id: 'id',
+    label: 'PDB ID',
+    renderCell: d =>
+      d.pdbId === pdbId ? (
+        <strong>{d.pdbId.toUpperCase()}</strong>
+      ) : (
+        d.pdbId.toUpperCase()
+      ),
+  },
+  {
+    id: 'method',
+    label: 'Method',
+  },
+  {
+    id: 'coverage',
+    label: 'Coverage',
+  },
+  {
+    id: 'resolution',
+    label: 'Resolution',
+  },
+  {
+    id: 'chain',
+    label: 'Chain',
+  },
+  {
+    id: 'start',
+    label: 'Position',
+    renderCell: d => `${d.start} - ${d.end}`,
+  },
+  {
+    id: 'view',
+    label: '',
+    renderCell: d => (
+      <a href="#" onClick={() => handleChangePdbId(d.pdbId)}>
+        View
+      </a>
+    ),
+  },
+];
+
+class Structure extends React.Component {
+  state = {};
+  componentDidMount() {
+    const { pdbId, pdbs } = this.props;
+    this.setState({ pdbId, pdbs });
+  }
+  handleChangePdbId = pdbId => {
+    this.setState({ pdbId });
+  };
+  render() {
+    const { pdbId, pdbs } = this.state;
+    return (
+      <div>
+        <Grid container>
+          <Grid item xs={12} md={6}>
+            {pdbId ? <LiteMolRenderer pdbId={pdbId} /> : null}
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <OtTable
+              message={
+                <React.Fragment>
+                  Currently viewing{' '}
+                  <strong>
+                    {pdbId ? pdbId.toUpperCase() : 'no structure'}
+                  </strong>
+                </React.Fragment>
+              }
+              loading={false}
+              error={null}
+              columns={columns(pdbId, this.handleChangePdbId)}
+              data={pdbs || []}
+            />
+          </Grid>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+export default Structure;

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,12 @@
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
 
+"@types/react-dom@^15.5.6":
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-15.5.8.tgz#e2fe3d95fc443c2dc2786eba99223f4e0eeeac22"
+  dependencies:
+    "@types/react" "^15"
+
 "@types/react-transition-group@^2.0.8":
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.14.tgz#afd0cd785a97f070b55765e9f9d76ff568269001"
@@ -879,6 +885,10 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^15", "@types/react@^15.6.16":
+  version "15.6.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.21.tgz#86fb19df382be9becee360290948bb3f66808f90"
 
 "@types/tapable@1.0.2":
   version "1.0.2"
@@ -5792,6 +5802,13 @@ listr@^0.14.2:
     listr-verbose-renderer "^0.5.0"
     p-map "^2.0.0"
     rxjs "^6.3.3"
+
+"litemol@https://github.com/dsehnal/LiteMol":
+  version "2.4.1"
+  resolved "https://github.com/dsehnal/LiteMol#33ead68e8fee63657067b59b368353ae2d23caf8"
+  dependencies:
+    "@types/react" "^15.6.16"
+    "@types/react-dom" "^15.5.6"
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This PR:
* integrates the LiteMol viewer (as used by UniProt)
* displays a list of PDB structures for a given target
* displays the secondary structure features of the sequence