### PR TITLE
Harmonise use of hyperlinks

### DIFF
--- a/src/components/CancerBiomarkers/FilterTable.js
+++ b/src/components/CancerBiomarkers/FilterTable.js
@@ -8,7 +8,7 @@ import { lighten } from 'polished';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 import classNames from 'classnames';
-import { OtTableRF, DataDownloader, PALETTE } from 'ot-ui';
+import { Link, OtTableRF, DataDownloader, PALETTE } from 'ot-ui';
 
 import DCContainer from '../DCContainer';
 import {
@@ -53,15 +53,13 @@ const getColumns = ({
       renderCell: rowData => {
         return rowData.diseases.map((disease, i) => {
           return (
-            <a
+            <Link
               key={i}
-              href={`https://www.targetvalidation.org/disease/${disease.id}`}
-              style={{ display: 'block' }}
-              target="_blank"
-              rel="noopener noreferrer"
+              external
+              to={`https://www.targetvalidation.org/disease/${disease.id}`}
             >
               {disease.name}
-            </a>
+            </Link>
           );
         });
       },
@@ -118,14 +116,9 @@ const getColumns = ({
         return (
           <Fragment>
             {rowData.sources.map((source, i) => (
-              <a
-                key={i}
-                href={source.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <Link key={i} external to={source.url}>
                 {source.name}
-              </a>
+              </Link>
             ))}
           </Fragment>
         );

--- a/src/components/CancerBiomarkers/index.js
+++ b/src/components/CancerBiomarkers/index.js
@@ -4,6 +4,8 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 
+import { Link } from 'ot-ui';
+
 import Widget from '../Widget';
 import CancerBiomarkersDetail from './Detail';
 import CancerBiomarkersWidgetIcon from '../../icons/CancerBiomarkersWidgetIcon';
@@ -49,14 +51,10 @@ const CancerBiomarkersWidget = ({
           <React.Fragment>
             Genomic biomarkers of drug responses, and their levels of clinical
             significance as described by{' '}
-            <a
-              href="https://europepmc.org/articles/PMC5875005"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <Link external to="https://europepmc.org/articles/PMC5875005">
               {' '}
               Tamborero et al. (2018)
-            </a>
+            </Link>
             . This data is manually curated by clinical and scientific
             communities in the field of precision oncology.
           </React.Fragment>

--- a/src/components/ChemicalProbes/Detail.js
+++ b/src/components/ChemicalProbes/Detail.js
@@ -3,7 +3,7 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import Typography from '@material-ui/core/Typography';
 
-import { OtTableRF, DataDownloader } from 'ot-ui';
+import { Link, OtTableRF, DataDownloader } from 'ot-ui';
 
 const query = gql`
   query ChemicalProbesQuery($ensgId: String!) {
@@ -38,9 +38,9 @@ const columns = [
       <React.Fragment>
         {rowData.sources.map((d, i, a) => (
           <React.Fragment key={i}>
-            <a href={d.url} target="_blank" rel="noopener noreferrer">
+            <Link external to={d.url}>
               {d.name}
-            </a>
+            </Link>
             {i < a.length - 1 ? ' / ' : ''}
           </React.Fragment>
         ))}
@@ -79,13 +79,9 @@ const ChemicalProbesDetail = ({ ensgId, symbol, sources }) => {
                 <React.Fragment>
                   <Typography>
                     Potential chemical probes can be explored with{' '}
-                    <a
-                      href={probeMinerUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+                    <Link external to={probeMinerUrl}>
                       ProbeMiner
-                    </a>
+                    </Link>
                     .
                   </Typography>
                 </React.Fragment>

--- a/src/components/KnownDrugs/FilterTable.js
+++ b/src/components/KnownDrugs/FilterTable.js
@@ -7,7 +7,7 @@ import * as d3 from 'd3';
 import { lighten } from 'polished';
 
 import DCContainer from '../DCContainer';
-import { OtTableRF, DataDownloader, PALETTE } from 'ot-ui';
+import { Link, OtTableRF, DataDownloader, PALETTE } from 'ot-ui';
 import classNames from 'classnames';
 import {
   upReducerKeyCount,
@@ -34,9 +34,9 @@ const getColumns = ({ filters }) => {
       id: 'disease',
       label: 'Disease',
       renderCell: d => (
-        <a href={'/disease/' + d.disease.id} rel="noopener noreferrer">
+        <Link to={'/disease/' + d.disease.id}>
           {_.capitalize(d.disease.name)}
-        </a>
+        </Link>
       ),
       comparator: generateComparatorFromAccessor(d => d.disease.name),
       export: d => d.disease.name,
@@ -62,13 +62,9 @@ const getColumns = ({ filters }) => {
       id: 'source',
       label: 'Source',
       renderCell: d => (
-        <a
-          href={d.clinicalTrial.sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Link external to={d.clinicalTrial.sourceUrl}>
           {d.clinicalTrial.sourceName}
-        </a>
+        </Link>
       ),
       comparator: generateComparatorFromAccessor(
         d => d.clinicalTrial.sourceName
@@ -79,9 +75,7 @@ const getColumns = ({ filters }) => {
       id: 'drug',
       label: 'Drug',
       renderCell: d => (
-        <a href={'/drug/' + d.drug.id} rel="noopener noreferrer">
-          {_.capitalize(d.drug.name)}
-        </a>
+        <Link to={'/drug/' + d.drug.id}>{_.capitalize(d.drug.name)}</Link>
       ),
       comparator: generateComparatorFromAccessor(d => d.drug.name),
       export: d => d.drug.name,
@@ -103,13 +97,9 @@ const getColumns = ({ filters }) => {
         <React.Fragment>
           {d.mechanismOfAction.name}
           <br />
-          <a
-            href={d.mechanismOfAction.sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <Link external to={d.mechanismOfAction.sourceUrl}>
             {d.mechanismOfAction.sourceName}
-          </a>
+          </Link>
         </React.Fragment>
       ),
       comparator: generateComparatorFromAccessor(

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'ot-ui';
+
 import MuiModal from '@material-ui/core/Modal';
 import Paper from '@material-ui/core/Paper';
 import withStyles from '@material-ui/core/styles/withStyles';
@@ -57,9 +59,9 @@ const Modal = ({ classes, open, onClose, children, header }) => {
               {header.sources.map((d, i) => (
                 <React.Fragment key={d.name}>
                   {i > 0 ? ' ' : null}
-                  <a href={d.url} target="_blank" rel="noopener noreferrer">
+                  <Link external to={d.url}>
                     {d.name}
-                  </a>
+                  </Link>
                 </React.Fragment>
               ))}
             </Typography>

--- a/src/components/Pathways/OverviewTab.js
+++ b/src/components/Pathways/OverviewTab.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 import classNames from 'classnames';
 
-import { DataDownloader, OtTableRF } from 'ot-ui';
+import { Link, DataDownloader, OtTableRF } from 'ot-ui';
 
 const styles = () => ({
   panelTitle: {
@@ -56,13 +56,9 @@ const getColumns = (
       id: 'id',
       label: 'Pathway ID',
       renderCell: d => (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href={`https://reactome.org/content/detail/${d.id}`}
-        >
+        <Link external to={`https://reactome.org/content/detail/${d.id}`}>
           {d.id}
-        </a>
+        </Link>
       ),
       renderFilter: () => (
         <Select
@@ -100,25 +96,23 @@ const getColumns = (
       label: 'View diagram',
       renderCell: d => (
         <React.Fragment>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href={`https://reactome.org/ContentService/exporter/diagram/${
+          <Link
+            external
+            to={`https://reactome.org/ContentService/exporter/diagram/${
               d.id
             }.svg`}
           >
             SVG
-          </a>{' '}
+          </Link>{' '}
           |{' '}
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href={`https://reactome.org/ContentService/exporter/diagram/${
+          <Link
+            external
+            to={`https://reactome.org/ContentService/exporter/diagram/${
               d.id
             }.png`}
           >
             PNG
-          </a>
+          </Link>
         </React.Fragment>
       ),
     },

--- a/src/components/ProteinInformation/Detail.js
+++ b/src/components/ProteinInformation/Detail.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import Typography from '@material-ui/core/Typography';
-import { Tabs, Tab } from 'ot-ui';
+import { Link, Tabs, Tab } from 'ot-ui';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 import Structure from './Structure';
@@ -129,13 +129,12 @@ class ProteinInformationModal extends React.Component {
                       {subCellularLocations.map((d, i) => (
                         <li key={i}>
                           <Typography>
-                            <a
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              href={`https://www.uniprot.org/locations/${d.id}`}
+                            <Link
+                              external
+                              to={`https://www.uniprot.org/locations/${d.id}`}
                             >
                               {d.name}
-                            </a>
+                            </Link>
                           </Typography>
                         </li>
                       ))}
@@ -178,15 +177,14 @@ class ProteinInformationModal extends React.Component {
                               <Fragment key={d.id}>
                                 {i > 0 ? ' | ' : null}
 
-                                <a
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  href={`https://www.uniprot.org/keywords/${
+                                <Link
+                                  external
+                                  to={`https://www.uniprot.org/keywords/${
                                     d.id
                                   }`}
                                 >
                                   {d.name}
-                                </a>
+                                </Link>
                               </Fragment>
                             ))}
                           </Typography>

--- a/src/components/ProteinInformation/Structure.js
+++ b/src/components/ProteinInformation/Structure.js
@@ -4,7 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 
-import { OtTable } from 'ot-ui';
+import { Link, OtTable } from 'ot-ui';
 
 import LiteMolRenderer from './LiteMolRenderer';
 
@@ -13,11 +13,7 @@ const columns = (pdbId, handleChangePdbId) => [
     id: 'id',
     label: 'PDB ID',
     renderCell: d => (
-      <a
-        href={`https://www.ebi.ac.uk/pdbe/entry/pdb/${d.pdbId}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <Link external to={`https://www.ebi.ac.uk/pdbe/entry/pdb/${d.pdbId}`}>
         {d.pdbId === pdbId ? (
           <span style={{ fontSize: '1.1rem', fontWeight: 'bold' }}>
             {d.pdbId.toUpperCase()}
@@ -25,7 +21,7 @@ const columns = (pdbId, handleChangePdbId) => [
         ) : (
           d.pdbId.toUpperCase()
         )}
-      </a>
+      </Link>
     ),
   },
   {
@@ -53,9 +49,9 @@ const columns = (pdbId, handleChangePdbId) => [
     id: 'view',
     label: 'Display',
     renderCell: d => (
-      <a href="#" onClick={() => handleChangePdbId(d.pdbId)}>
+      <Link to="#" onClick={() => handleChangePdbId(d.pdbId)}>
         View
-      </a>
+      </Link>
     ),
   },
 ];

--- a/src/components/RelatedTargets/Detail.js
+++ b/src/components/RelatedTargets/Detail.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Link as RouterLink } from 'react-router-dom';
-import Link from '@material-ui/core/Link';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import { OtTableRF, ExternalLink } from 'ot-ui';
+import { OtTableRF, Link } from 'ot-ui';
 import Intersection from '../Intersection';
 
 const query = gql`
@@ -58,11 +56,12 @@ let SharedDiseases = ({ d, classes }) => {
         ab={d.diseaseCountAAndB}
         b={d.diseaseCountBNotA}
       />
-      <ExternalLink
-        href={`https://targetvalidation.org/summary?targets=${compressedA},${compressedB}`}
+      <Link
+        external
+        to={`https://targetvalidation.org/summary?targets=${compressedA},${compressedB}`}
       >
         See all shared disease associations
-      </ExternalLink>
+      </Link>
     </div>
   );
 };
@@ -73,11 +72,7 @@ const columns = symbol => [
   {
     id: 'B.symbol',
     label: 'Related target',
-    renderCell: d => (
-      <Link component={RouterLink} to={`../${d.B.id}`}>
-        {d.B.symbol}
-      </Link>
-    ),
+    renderCell: d => <Link to={`../${d.B.id}`}>{d.B.symbol}</Link>,
     comparator: (a, b) => {
       if (a.B.symbol <= b.B.symbol) {
         return -1;

--- a/src/components/TargetSummary.js
+++ b/src/components/TargetSummary.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Typography from '@material-ui/core/Typography';
-import { ExternalLink } from 'ot-ui';
+import { Link } from 'ot-ui';
 
 import LongText from './LongText';
 import TargetIcon from '../icons/TargetIcon';
@@ -96,19 +96,19 @@ const TargetSummary = ({
             <Grid container>
               <Typography>
                 Ensembl:{' '}
-                <ExternalLink
-                  className={classes.titleLink}
-                  href={`http://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${ensgId}`}
+                <Link
+                  external
+                  to={`http://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${ensgId}`}
                 >
                   {ensgId}
-                </ExternalLink>{' '}
+                </Link>{' '}
                 | UniProt:{' '}
-                <ExternalLink
-                  className={classes.titleLink}
-                  href={`https://www.uniprot.org/uniprot/${uniprotId}`}
+                <Link
+                  external
+                  to={`https://www.uniprot.org/uniprot/${uniprotId}`}
                 >
                   {uniprotId}
-                </ExternalLink>
+                </Link>
               </Typography>
             </Grid>
           </Grid>


### PR DESCRIPTION
This PR rolls out the use of the `Link` component from `ot-ui` for consistent usage of hyperlinks.