### PR TITLE
Harmonise use of ot-ui Page component

### DIFF
--- a/src/pages/BasePage.js
+++ b/src/pages/BasePage.js
@@ -1,33 +1,20 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
-import Grid from '@material-ui/core/Grid';
-import withStyles from '@material-ui/core/styles/withStyles';
-import { NavBar, Footer } from 'ot-ui';
+import { Page, NavBar, Footer } from 'ot-ui';
 
 import { externalLinks } from '../constants';
 
-const styles = theme => ({
-  container: {
-    padding: '40px 24px',
-  },
-});
+const BasePage = ({ children, classes }) => (
+  <Page
+    header={<NavBar name="Platform" />}
+    footer={<Footer externalLinks={externalLinks} />}
+  >
+    <Helmet
+      defaultTitle="Open Targets Platform"
+      titleTemplate="%s | Open Targets Platform"
+    />
+    {children}
+  </Page>
+);
 
-const BasePage = ({ children, classes }) => {
-  return (
-    <Fragment>
-      <Helmet
-        defaultTitle="Open Targets Platform"
-        titleTemplate="%s | Open Targets Platform"
-      />
-      <NavBar name="Platform" />
-      <Grid className={classes.container} container justify="space-around">
-        <Grid item md={11}>
-          {children}
-        </Grid>
-      </Grid>
-      <Footer externalLinks={externalLinks} />
-    </Fragment>
-  );
-};
-
-export default withStyles(styles)(BasePage);
+export default BasePage;

--- a/src/pages/BasePage.js
+++ b/src/pages/BasePage.js
@@ -4,7 +4,7 @@ import { Page, NavBar, Footer } from 'ot-ui';
 
 import { externalLinks } from '../constants';
 
-const BasePage = ({ children, classes }) => (
+const BasePage = ({ children }) => (
   <Page
     header={<NavBar name="Platform" />}
     footer={<Footer externalLinks={externalLinks} />}


### PR DESCRIPTION
This PR removes styling from `platform-app`, moving it into the `ot-ui` `Page` component.