### PR TITLE
Add interactions viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "litemol": "https://github.com/dsehnal/LiteMol",
     "lodash": "^4.17.11",
     "node-sass": "^4.12.0",
-    "ot-ui": "^0.0.82",
+    "ot-ui": "^0.0.85",
     "polished": "^2.3.0",
     "react": "^16.8.6",
     "react-apollo": "^2.2.4",

--- a/src/components/OverviewTab.js
+++ b/src/components/OverviewTab.js
@@ -24,6 +24,7 @@ const overviewQuery = gql`
   query TargetQuery($ensgId: String!) {
     target(ensgId: $ensgId) {
       id
+      uniprotId
       summaries {
         drugs {
           drugCount
@@ -195,6 +196,7 @@ class OverviewTab extends Component {
             return null;
           }
 
+          const { uniprotId, summaries } = data.target;
           const {
             drugs,
             chemicalProbes,
@@ -209,7 +211,7 @@ class OverviewTab extends Component {
             tractability,
             variation,
             homology,
-          } = data.target.summaries;
+          } = summaries;
 
           return (
             <Fragment>
@@ -281,6 +283,7 @@ class OverviewTab extends Component {
                   <ProteinInteractionsWidget
                     ensgId={ensgId}
                     symbol={symbol}
+                    uniprotId={uniprotId}
                     proteinInteractions={proteinInteractions}
                   />
                 )}

--- a/src/components/OverviewTab.js
+++ b/src/components/OverviewTab.js
@@ -103,6 +103,10 @@ const overviewQuery = gql`
           ppi
           pathways
           enzymeSubstrate
+          sources {
+            name
+            url
+          }
         }
         rnaAndProteinExpression {
           rnaBaselineExpression
@@ -275,6 +279,7 @@ class OverviewTab extends Component {
                   lowerCaseTerm
                 ) && (
                   <ProteinInteractionsWidget
+                    ensgId={ensgId}
                     symbol={symbol}
                     proteinInteractions={proteinInteractions}
                   />

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -372,6 +372,89 @@ class ProteinInteractionsDetail extends React.Component {
                         {maxNeighbourCount}
                       </text>
                     </g>
+                    <g transform={`translate(${20},${20})`}>
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r={circleRadius}
+                        stroke="#000"
+                        strokeWidth="2"
+                        fill="none"
+                      />
+                      <text
+                        x="30"
+                        y="10"
+                        fill="#000"
+                        fontSize="12px"
+                        fontWeight="bold"
+                        textAnchor="start"
+                        alignmentBaseline="central"
+                      >
+                        Selection
+                      </text>
+                      <circle
+                        cx="10"
+                        cy="30"
+                        r={circleRadius}
+                        stroke="#bbb"
+                        fill="none"
+                      />
+                      <text
+                        x="30"
+                        y="30"
+                        fill="#777"
+                        fontSize="10px"
+                        textAnchor="start"
+                        alignmentBaseline="central"
+                      >
+                        Neighbour of selection
+                      </text>
+                      <circle
+                        cx="10"
+                        cy="50"
+                        r={circleRadius}
+                        stroke="#bbb"
+                        fill="none"
+                      />
+                      <text
+                        x="30"
+                        y="50"
+                        fill="#ddd"
+                        fontSize="10px"
+                        textAnchor="start"
+                        alignmentBaseline="central"
+                      >
+                        Not a neighbour of selection
+                      </text>
+                      {/* <text
+                        x={-10}
+                        y={10}
+                        fill="#bbb"
+                        textAnchor="end"
+                        alignmentBaseline="central"
+                      >
+                        {0}
+                      </text>
+                      {legendData.map((d, i) => (
+                        <rect
+                          x={i * 20}
+                          y={0}
+                          width={20}
+                          height={20}
+                          fill={colour(d + 1)}
+                          stroke="#bbb"
+                        />
+                      ))}
+                      <text
+                        x={legendData.length * 20 + 10}
+                        y={10}
+                        fill="#bbb"
+                        textAnchor="start"
+                        alignmentBaseline="central"
+                      >
+                        {maxNeighbourCount}
+                      </text> */}
+                    </g>
                     {selectedUniprotIds.length > 0 ? (
                       <g
                         fill="none"

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withContentRect } from 'react-measure';
+import classNames from 'classnames';
 import * as d3 from 'd3';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
@@ -13,7 +14,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
 import Chip from '@material-ui/core/Chip';
 
-import { Link, OtTableRF, DataDownloader } from 'ot-ui';
+import { Link, OtTableRF, PALETTE } from 'ot-ui';
 
 const query = gql`
   query ProteinInteractionsQuery($ensgId: String!) {
@@ -43,12 +44,54 @@ const query = gql`
   }
 `;
 
+const sourceTypeColors = {
+  enzymeSubstrate: PALETTE.red, //'#fcc',
+  pathways: PALETTE.green, //'#cfc',
+  ppi: PALETTE.purple, //'#ccf',
+};
+
 const styles = theme => ({
   formControl: {
     margin: theme.spacing.unit * 3,
   },
   chip: {
     margin: theme.spacing.unit * 0.5,
+  },
+  chipSource: {
+    margin: '1px',
+    height: '24px',
+    color: 'white',
+  },
+  chipSourcePathways: {
+    backgroundColor: sourceTypeColors.pathways,
+    // border: `1px solid black`,
+    // border: `1px solid ${sourceTypeColors.pathways}`,
+  },
+  chipSourcePPI: {
+    backgroundColor: sourceTypeColors.ppi,
+    // border: `1px solid black`,
+    // border: `1px solid ${sourceTypeColors.ppi}`,
+  },
+  chipSourceEnzymeSubstrate: {
+    backgroundColor: sourceTypeColors.enzymeSubstrate,
+    // border: `1px solid black`,
+    // border: `1px solid ${sourceTypeColors.enzymeSubstrate}`,
+  },
+  checked: {},
+  checkboxPathways: {
+    '&$checked': {
+      color: sourceTypeColors.pathways,
+    },
+  },
+  checkboxPPI: {
+    '&$checked': {
+      color: sourceTypeColors.ppi,
+    },
+  },
+  checkboxEnzymeSubstrate: {
+    '&$checked': {
+      color: sourceTypeColors.enzymeSubstrate,
+    },
   },
 });
 
@@ -226,6 +269,10 @@ class ProteinInteractionsDetail extends React.Component {
                       <FormControlLabel
                         control={
                           <Checkbox
+                            classes={{
+                              root: classes.checkboxEnzymeSubstrate,
+                              checked: classes.checked,
+                            }}
                             checked={interactionTypes.enzymeSubstrate}
                             onChange={this.handleInteractionTypeChange(
                               'enzymeSubstrate'
@@ -242,6 +289,10 @@ class ProteinInteractionsDetail extends React.Component {
                       <FormControlLabel
                         control={
                           <Checkbox
+                            classes={{
+                              root: classes.checkboxPathways,
+                              checked: classes.checked,
+                            }}
                             checked={interactionTypes.pathways}
                             onChange={this.handleInteractionTypeChange(
                               'pathways'
@@ -258,6 +309,10 @@ class ProteinInteractionsDetail extends React.Component {
                       <FormControlLabel
                         control={
                           <Checkbox
+                            classes={{
+                              root: classes.checkboxPPI,
+                              checked: classes.checked,
+                            }}
                             checked={interactionTypes.ppi}
                             onChange={this.handleInteractionTypeChange('ppi')}
                             value="ppi"
@@ -274,6 +329,7 @@ class ProteinInteractionsDetail extends React.Component {
                 <Typography>Selection</Typography>
                 {selectedUniprotIds.map(uniprotId => (
                   <Chip
+                    key={uniprotId}
                     className={classes.chip}
                     color="primary"
                     label={nodes.find(n => n.uniprotId === uniprotId).symbol}
@@ -304,7 +360,49 @@ class ProteinInteractionsDetail extends React.Component {
                     {
                       id: 'sources',
                       label: 'Sources',
-                      renderCell: d => d.sources.join(', '),
+                      renderCell: d => (
+                        <React.Fragment>
+                          {interactionTypes.enzymeSubstrate
+                            ? d.enzymeSubstrateSources.map(s => (
+                                <Chip
+                                  className={classNames(
+                                    classes.chipSource,
+                                    classes.chipSourceEnzymeSubstrate
+                                  )}
+                                  key={s}
+                                  label={s}
+                                  color={sourceTypeColors.enzymeSubstrate}
+                                />
+                              ))
+                            : null}
+                          {interactionTypes.pathways
+                            ? d.pathwaysSources.map(s => (
+                                <Chip
+                                  className={classNames(
+                                    classes.chipSource,
+                                    classes.chipSourcePathways
+                                  )}
+                                  key={s}
+                                  label={s}
+                                  color={sourceTypeColors.pathways}
+                                />
+                              ))
+                            : null}
+                          {interactionTypes.ppi
+                            ? d.ppiSources.map(s => (
+                                <Chip
+                                  className={classNames(
+                                    classes.chipSource,
+                                    classes.chipSourcePPI
+                                  )}
+                                  key={s}
+                                  label={s}
+                                  color={sourceTypeColors.ppi}
+                                />
+                              ))
+                            : null}
+                        </React.Fragment>
+                      ),
                     },
                     {
                       id: 'pmIds',

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -332,7 +332,7 @@ class ProteinInteractionsDetail extends React.Component {
                     component="fieldset"
                     className={classes.formControl}
                   >
-                    <FormGroup>
+                    <FormGroup row>
                       <FormControlLabel
                         control={
                           <Checkbox

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 import _ from 'lodash';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -147,7 +147,7 @@ class ProteinInteractionsDetail extends React.Component {
     this.setState({ selectedUniprotIds: [uniprotId] });
   }
   render() {
-    const { classes, ensgId } = this.props;
+    const { classes, ensgId, symbol } = this.props;
     const { interactionTypes, selectedUniprotIds, tooltip } = this.state;
     return (
       <Query query={query} variables={{ ensgId }} fetchPolicy="no-cache">
@@ -271,6 +271,7 @@ class ProteinInteractionsDetail extends React.Component {
                     handleProteinClick: this.handleProteinClick,
                     handleMouseOver: this.handleMouseOver,
                     handleMouseLeave: this.handleMouseLeave,
+                    filenameStem: `${symbol}-protein-interactions`,
                   }}
                 />
               </Grid>

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -1,7 +1,292 @@
 import React from 'react';
+import { withContentRect } from 'react-measure';
+import * as d3 from 'd3';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Typography from '@material-ui/core/Typography';
+import FormLabel from '@material-ui/core/FormLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Grid from '@material-ui/core/Grid';
 
-const ProteinInteractionsDetail = () => {
-  return <div>Protein Interactions</div>;
-};
+const query = gql`
+  query ProteinInteractionsQuery($ensgId: String!) {
+    target(ensgId: $ensgId) {
+      details {
+        proteinInteractions {
+          nodes {
+            uniprotId
+            ensgId
+            symbol
+          }
+          edges {
+            source
+            target
+            isDirected
+            isStimulation
+            isInhibition
+            pmIds
+            sources
+            pathwaysSources
+            enzymeSubstrateSources
+            ppiSources
+          }
+        }
+      }
+    }
+  }
+`;
 
-export default ProteinInteractionsDetail;
+const styles = theme => ({
+  formControl: {
+    margin: theme.spacing.unit * 3,
+  },
+});
+
+class ProteinInteractionsDetail extends React.Component {
+  state = {
+    interactionTypes: {
+      enzymeSubstrate: true,
+      pathways: true,
+      ppi: true,
+    },
+    selectedUniprotIds: [],
+  };
+  static getDerivedStateFromProps(props) {
+    const { width = 600 } = props.contentRect.bounds;
+    return { width };
+  }
+  handleInteractionTypeChange = interactionType => event => {
+    const { interactionTypes } = this.state;
+    this.setState({
+      interactionTypes: {
+        ...interactionTypes,
+        [interactionType]: event.target.checked,
+      },
+    });
+  };
+  handleProteinClick = uniprotId => {
+    const { selectedUniprotIds } = this.state;
+    if (selectedUniprotIds.indexOf(uniprotId) >= 0) {
+      this.setState({
+        selectedUniprotIds: selectedUniprotIds.filter(d => d !== uniprotId),
+      });
+    } else {
+      this.setState({ selectedUniprotIds: [uniprotId, ...selectedUniprotIds] });
+    }
+  };
+  render() {
+    const { classes, ensgId, symbol, measureRef } = this.props;
+    const { width, interactionTypes, selectedUniprotIds } = this.state;
+    const height = Math.min(width, 700);
+    return (
+      <Query query={query} variables={{ ensgId }} fetchPolicy="no-cache">
+        {({ loading, error, data }) => {
+          if (loading || error) {
+            return null;
+          }
+
+          if (!data.target) {
+            return null;
+          }
+
+          const {
+            nodes: nodesRaw,
+            edges,
+          } = data.target.details.proteinInteractions;
+          const nodes = nodesRaw.map(n => ({
+            ...n,
+            neighbourCount: edges.filter(
+              e => e.source === n.uniprotId || e.target === n.uniprotId
+            ).length,
+          }));
+          const nodeCount = nodes.length;
+
+          // helpers
+          const padding = 100;
+          const radius = height / 2 - padding;
+          const diameter = 2 * radius;
+          const textOffset = 10;
+          const textRadius = radius + textOffset;
+          const circleRadius = 4;
+          const colour = d3
+            .scaleLog()
+            .domain(d3.extent(nodes, n => n.neighbourCount + 1))
+            .range(['#fff', '#3489ca']);
+
+          // order alphabetically
+          const uniprotIdToIndex = new Map(
+            nodes
+              .sort((a, b) => d3.ascending(a.symbol, b.symbol))
+              .map((d, i) => [d.uniprotId, i])
+          );
+          const nodeToAngleRad = n =>
+            (2 * Math.PI * uniprotIdToIndex.get(n)) / nodeCount;
+          const nodeToAngleDeg = n =>
+            (360 * uniprotIdToIndex.get(n)) / nodeCount;
+          const nodeToColour = n => colour(n.neighbourCount + 1);
+          const isInRightSemiCircle = n =>
+            uniprotIdToIndex.get(n) / nodeCount < 0.5;
+
+          return (
+            <Grid container>
+              <Grid item sm={12} md={3}>
+                <div>
+                  <FormControl
+                    component="fieldset"
+                    className={classes.formControl}
+                  >
+                    <FormLabel component="legend">
+                      Filter by interaction type
+                    </FormLabel>
+                    <FormGroup>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={interactionTypes.enzymeSubstrate}
+                            onChange={this.handleInteractionTypeChange(
+                              'enzymeSubstrate'
+                            )}
+                            value="enzymeSubstrate"
+                          />
+                        }
+                        label="Enzyme-substrate"
+                      />
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={interactionTypes.pathways}
+                            onChange={this.handleInteractionTypeChange(
+                              'pathways'
+                            )}
+                            value="pathways"
+                          />
+                        }
+                        label="Pathways"
+                      />
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={interactionTypes.ppi}
+                            onChange={this.handleInteractionTypeChange('ppi')}
+                            value="ppi"
+                          />
+                        }
+                        label="PPI"
+                      />
+                    </FormGroup>
+                  </FormControl>
+                </div>
+                <Typography>Interaction details</Typography>
+              </Grid>
+              <Grid item sm={12} md={9}>
+                <div ref={measureRef}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={width}
+                    height={height}
+                  >
+                    <g
+                      fill="none"
+                      stroke="#999"
+                      strokeOpacity={0.6}
+                      transform={`translate(${width / 2},${height / 2})`}
+                    >
+                      {edges
+                        .filter(
+                          e =>
+                            (interactionTypes.ppi && e.ppiSources.length > 0) ||
+                            (interactionTypes.pathways &&
+                              e.pathwaysSources.length > 0) ||
+                            (interactionTypes.enzymeSubstrate &&
+                              e.enzymeSubstrateSources.length > 0)
+                        )
+
+                        .filter(e =>
+                          selectedUniprotIds.length > 1
+                            ? selectedUniprotIds.indexOf(e.source) >= 0 &&
+                              selectedUniprotIds.indexOf(e.target) >= 0
+                            : selectedUniprotIds.length === 1
+                            ? selectedUniprotIds.indexOf(e.source) >= 0 ||
+                              selectedUniprotIds.indexOf(e.target) >= 0
+                            : true
+                        )
+                        .map(e => {
+                          let fromAngle = nodeToAngleRad(e.source) + 0.001;
+                          let toAngle = nodeToAngleRad(e.target) + 0.001;
+                          let fromX =
+                            ((diameter - circleRadius) / 2) *
+                            Math.sin(fromAngle);
+                          let fromY =
+                            (-(diameter - circleRadius) / 2) *
+                            Math.cos(fromAngle);
+                          let toX =
+                            ((diameter - circleRadius) / 2) * Math.sin(toAngle);
+                          let toY =
+                            (-(diameter - circleRadius) / 2) *
+                            Math.cos(toAngle);
+                          const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
+                          return <path d={d} />;
+                        })}
+                    </g>
+                    <g
+                      style={{ font: '10px sans-serif' }}
+                      transform={`translate(${width / 2},${height / 2})`}
+                    >
+                      {nodes.map(n => {
+                        const angleRad = nodeToAngleRad(n.uniprotId);
+                        const angleDeg = nodeToAngleDeg(n.uniprotId);
+                        const isRightHalf = isInRightSemiCircle(n.uniprotId);
+                        const isSelected =
+                          selectedUniprotIds.indexOf(n.uniprotId) >= 0;
+                        return (
+                          <g
+                            key={n.uniprotId}
+                            transform={`translate(${textRadius *
+                              Math.sin(angleRad)},${-textRadius *
+                              Math.cos(angleRad)})`}
+                            onClick={() => this.handleProteinClick(n.uniprotId)}
+                          >
+                            <circle
+                              cx="0"
+                              cy="0"
+                              r={circleRadius}
+                              fill={nodeToColour(n)}
+                              stroke={isSelected ? '#000' : '#bbb'}
+                              strokeWidth={isSelected ? 2 : 1}
+                            />
+                            <text
+                              x="0"
+                              y="0"
+                              fill={isSelected ? '#000' : '#bbb'}
+                              fontWeight={isSelected ? 'bold' : null}
+                              textAnchor={isRightHalf ? 'start' : 'end'}
+                              alignmentBaseline="central"
+                              transform={`rotate(${(isRightHalf ? 270 : 90) +
+                                angleDeg}) translate(${
+                                isRightHalf ? textOffset : -textOffset
+                              }, 0)`}
+                            >
+                              {n.symbol} ({n.neighbourCount})
+                            </text>
+                          </g>
+                        );
+                      })}
+                    </g>
+                  </svg>
+                </div>
+              </Grid>
+            </Grid>
+          );
+        }}
+      </Query>
+    );
+  }
+}
+
+export default withContentRect('bounds')(
+  withStyles(styles)(ProteinInteractionsDetail)
+);

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -45,9 +45,9 @@ const query = gql`
 `;
 
 const sourceTypeColors = {
-  enzymeSubstrate: PALETTE.red, //'#fcc',
-  pathways: PALETTE.green, //'#cfc',
-  ppi: PALETTE.purple, //'#ccf',
+  enzymeSubstrate: PALETTE.red,
+  pathways: PALETTE.green,
+  ppi: PALETTE.purple,
 };
 
 const styles = theme => ({
@@ -65,18 +65,12 @@ const styles = theme => ({
   },
   chipSourcePathways: {
     backgroundColor: sourceTypeColors.pathways,
-    // border: `1px solid black`,
-    // border: `1px solid ${sourceTypeColors.pathways}`,
   },
   chipSourcePPI: {
     backgroundColor: sourceTypeColors.ppi,
-    // border: `1px solid black`,
-    // border: `1px solid ${sourceTypeColors.ppi}`,
   },
   chipSourceEnzymeSubstrate: {
     backgroundColor: sourceTypeColors.enzymeSubstrate,
-    // border: `1px solid black`,
-    // border: `1px solid ${sourceTypeColors.enzymeSubstrate}`,
   },
   checked: {},
   checkboxPathways: {

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -8,7 +8,6 @@ import Typography from '@material-ui/core/Typography';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
 import Chip from '@material-ui/core/Chip';
 
@@ -16,7 +15,8 @@ import { Button, ListTooltip } from 'ot-ui';
 
 import InteractionsPlot from './InteractionsPlot';
 import InteractionsTable from './InteractionsTable';
-import SourceChip, { sourceTypeColors } from './SourceChip';
+import SourceChip from './SourceChip';
+import SourceCheckbox from './SourceCheckbox';
 
 const query = gql`
   query ProteinInteractionsQuery($ensgId: String!) {
@@ -54,22 +54,6 @@ const styles = theme => ({
   chip: {
     margin: theme.spacing.unit * 0.5,
   },
-  checked: {},
-  checkboxPathways: {
-    '&$checked': {
-      color: sourceTypeColors.pathways,
-    },
-  },
-  checkboxPPI: {
-    '&$checked': {
-      color: sourceTypeColors.ppi,
-    },
-  },
-  checkboxEnzymeSubstrate: {
-    '&$checked': {
-      color: sourceTypeColors.enzymeSubstrate,
-    },
-  },
 });
 
 class ProteinInteractionsDetail extends React.Component {
@@ -86,7 +70,6 @@ class ProteinInteractionsDetail extends React.Component {
       anchorEl: null,
     },
   };
-
   handleInteractionTypeChange = interactionType => event => {
     const { interactionTypes } = this.state;
     this.setState({
@@ -279,7 +262,6 @@ class ProteinInteractionsDetail extends React.Component {
                     'interaction-plot-container'
                   )}
                 />
-
                 <InteractionsPlot
                   {...{
                     nodes,
@@ -296,7 +278,6 @@ class ProteinInteractionsDetail extends React.Component {
               <Grid item sm={12} lg={6}>
                 <div>
                   <Typography>Filter by interaction type</Typography>
-
                   <FormControl
                     component="fieldset"
                     className={classes.formControl}
@@ -304,11 +285,8 @@ class ProteinInteractionsDetail extends React.Component {
                     <FormGroup row>
                       <FormControlLabel
                         control={
-                          <Checkbox
-                            classes={{
-                              root: classes.checkboxEnzymeSubstrate,
-                              checked: classes.checked,
-                            }}
+                          <SourceCheckbox
+                            sourceType="enzymeSubstrate"
                             checked={interactionTypes.enzymeSubstrate}
                             onChange={this.handleInteractionTypeChange(
                               'enzymeSubstrate'
@@ -324,11 +302,8 @@ class ProteinInteractionsDetail extends React.Component {
                       />
                       <FormControlLabel
                         control={
-                          <Checkbox
-                            classes={{
-                              root: classes.checkboxPathways,
-                              checked: classes.checked,
-                            }}
+                          <SourceCheckbox
+                            sourceType="pathways"
                             checked={interactionTypes.pathways}
                             onChange={this.handleInteractionTypeChange(
                               'pathways'
@@ -344,11 +319,8 @@ class ProteinInteractionsDetail extends React.Component {
                       />
                       <FormControlLabel
                         control={
-                          <Checkbox
-                            classes={{
-                              root: classes.checkboxPPI,
-                              checked: classes.checked,
-                            }}
+                          <SourceCheckbox
+                            sourceType="ppi"
                             checked={interactionTypes.ppi}
                             onChange={this.handleInteractionTypeChange('ppi')}
                             value="ppi"

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -426,34 +426,6 @@ class ProteinInteractionsDetail extends React.Component {
                       >
                         Not a neighbour of selection
                       </text>
-                      {/* <text
-                        x={-10}
-                        y={10}
-                        fill="#bbb"
-                        textAnchor="end"
-                        alignmentBaseline="central"
-                      >
-                        {0}
-                      </text>
-                      {legendData.map((d, i) => (
-                        <rect
-                          x={i * 20}
-                          y={0}
-                          width={20}
-                          height={20}
-                          fill={colour(d + 1)}
-                          stroke="#bbb"
-                        />
-                      ))}
-                      <text
-                        x={legendData.length * 20 + 10}
-                        y={10}
-                        fill="#bbb"
-                        textAnchor="start"
-                        alignmentBaseline="central"
-                      >
-                        {maxNeighbourCount}
-                      </text> */}
                     </g>
                     {selectedUniprotIds.length > 0 ? (
                       <g

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -307,7 +307,30 @@ class ProteinInteractionsDetail extends React.Component {
 
           return (
             <Grid container>
-              <Grid item sm={12} md={6}>
+              <Grid id="interaction-plot-container" item sm={12} lg={6}>
+                <ListTooltip
+                  open={tooltip.open}
+                  anchorEl={tooltip.anchorEl}
+                  dataList={tooltip.data ? tooltip.data : []}
+                  container={document.getElementById(
+                    'interaction-plot-container'
+                  )}
+                />
+
+                <InteractionsPlot
+                  {...{
+                    nodes,
+                    selectedUniprotIds,
+                    edgesFiltered,
+                    edgesFilteredWithinSelectedUniprotIds,
+                    edgesFilteredWithoutSelectedUniprotIds,
+                    handleProteinClick: this.handleProteinClick,
+                    handleMouseOver: this.handleMouseOver,
+                    handleMouseLeave: this.handleMouseLeave,
+                  }}
+                />
+              </Grid>
+              <Grid item sm={12} lg={6}>
                 <div>
                   <Typography>Filter by interaction type</Typography>
 
@@ -501,29 +524,6 @@ class ProteinInteractionsDetail extends React.Component {
                         : edgesFilteredWithoutSelectedUniprotIds
                       : edgesFiltered
                   }
-                />
-              </Grid>
-              <Grid id="interaction-plot-container" item sm={12} md={6}>
-                <ListTooltip
-                  open={tooltip.open}
-                  anchorEl={tooltip.anchorEl}
-                  dataList={tooltip.data ? tooltip.data : []}
-                  container={document.getElementById(
-                    'interaction-plot-container'
-                  )}
-                />
-
-                <InteractionsPlot
-                  {...{
-                    nodes,
-                    selectedUniprotIds,
-                    edgesFiltered,
-                    edgesFilteredWithinSelectedUniprotIds,
-                    edgesFilteredWithoutSelectedUniprotIds,
-                    handleProteinClick: this.handleProteinClick,
-                    handleMouseOver: this.handleMouseOver,
-                    handleMouseLeave: this.handleMouseLeave,
-                  }}
                 />
               </Grid>
             </Grid>

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -1,21 +1,19 @@
 import React from 'react';
-import { withContentRect } from 'react-measure';
 import classNames from 'classnames';
-import * as d3 from 'd3';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Typography from '@material-ui/core/Typography';
-import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
 import Chip from '@material-ui/core/Chip';
-import Paper from '@material-ui/core/Paper';
 
-import { Button, Link, OtTableRF, PALETTE } from 'ot-ui';
+import { Button, Link, OtTableRF, ListTooltip, PALETTE } from 'ot-ui';
+
+import InteractionsPlot from './InteractionsPlot';
 
 const query = gql`
   query ProteinInteractionsQuery($ensgId: String!) {
@@ -105,11 +103,13 @@ class ProteinInteractionsDetail extends React.Component {
       ppi: true,
     },
     selectedUniprotIds: [],
+    tooltip: {
+      open: false,
+      anchorData: null,
+      anchorEl: null,
+    },
   };
-  static getDerivedStateFromProps(props) {
-    const { width = 600 } = props.contentRect.bounds;
-    return { width };
-  }
+
   handleInteractionTypeChange = interactionType => event => {
     const { interactionTypes } = this.state;
     this.setState({
@@ -129,14 +129,36 @@ class ProteinInteractionsDetail extends React.Component {
       this.setState({ selectedUniprotIds: [...selectedUniprotIds, uniprotId] });
     }
   };
+  handleMouseOver = d => {
+    const anchorEl = document.querySelector(`#node-${d.uniprotId}`);
+    const data = [
+      { label: 'Protein', value: d.symbol },
+      { label: 'Edges within selection', value: d.neighbourCountWithin },
+    ];
+    this.setState({
+      tooltip: {
+        open: true,
+        data,
+        anchorEl,
+      },
+    });
+  };
+  handleMouseLeave = () => {
+    this.setState({
+      tooltip: {
+        open: false,
+        data: null,
+        anchorEl: null,
+      },
+    });
+  };
   componentDidMount() {
     const { uniprotId } = this.props;
     this.setState({ selectedUniprotIds: [uniprotId] });
   }
   render() {
-    const { classes, ensgId, symbol, measureRef } = this.props;
-    const { width, interactionTypes, selectedUniprotIds } = this.state;
-    const height = Math.min(width, 700);
+    const { classes, ensgId } = this.props;
+    const { interactionTypes, selectedUniprotIds, tooltip } = this.state;
     return (
       <Query query={query} variables={{ ensgId }} fetchPolicy="no-cache">
         {({ loading, error, data }) => {
@@ -220,43 +242,6 @@ class ProteinInteractionsDetail extends React.Component {
                 e => e.source === n.uniprotId || e.target === n.uniprotId
               ).length,
           }));
-          const nodeCount = nodes.length;
-          const maxNeighbourCount = d3.max(nodes, n => n.neighbourCount);
-          const legendInterval = maxNeighbourCount / 5;
-          const legendData = [
-            0,
-            legendInterval,
-            legendInterval * 2,
-            legendInterval * 3,
-            legendInterval * 4,
-            legendInterval * 5,
-          ];
-
-          // helpers
-          const padding = 100;
-          const radius = height / 2 - padding;
-          const diameter = 2 * radius;
-          const textOffset = 10;
-          const textRadius = radius + textOffset;
-          const circleRadius = 4;
-          const colour = d3
-            .scaleLog()
-            .domain(d3.extent(nodes, n => n.neighbourCount + 1))
-            .range(['#fff', '#3489ca']);
-
-          // order alphabetically
-          const uniprotIdToIndex = new Map(
-            nodes
-              .sort((a, b) => d3.ascending(a.symbol, b.symbol))
-              .map((d, i) => [d.uniprotId, i])
-          );
-          const nodeToAngleRad = n =>
-            (2 * Math.PI * uniprotIdToIndex.get(n)) / nodeCount;
-          const nodeToAngleDeg = n =>
-            (360 * uniprotIdToIndex.get(n)) / nodeCount;
-          const nodeToColour = n => colour(n.neighbourCount + 1);
-          const isInRightSemiCircle = n =>
-            uniprotIdToIndex.get(n) / nodeCount < 0.5;
 
           return (
             <Grid container>
@@ -456,217 +441,33 @@ class ProteinInteractionsDetail extends React.Component {
                   }
                 />
               </Grid>
-              <Grid item sm={12} md={6}>
-                <div ref={measureRef}>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width={width}
-                    height={height}
-                  >
-                    <g
-                      transform={`translate(${width -
-                        20 * (legendData.length + 3)},${20})`}
-                    >
-                      <text
-                        x={-10}
-                        y={10}
-                        fill="#bbb"
-                        textAnchor="end"
-                        alignmentBaseline="central"
-                      >
-                        {0}
-                      </text>
-                      {legendData.map((d, i) => (
-                        <rect
-                          x={i * 20}
-                          y={0}
-                          width={20}
-                          height={20}
-                          fill={colour(d + 1)}
-                          stroke="#bbb"
-                        />
-                      ))}
-                      <text
-                        x={legendData.length * 20 + 10}
-                        y={10}
-                        fill="#bbb"
-                        textAnchor="start"
-                        alignmentBaseline="central"
-                      >
-                        {maxNeighbourCount}
-                      </text>
-                    </g>
-                    <g transform={`translate(${20},${20})`}>
-                      <circle
-                        cx="10"
-                        cy="10"
-                        r={circleRadius}
-                        stroke="#000"
-                        strokeWidth="2"
-                        fill="none"
-                      />
-                      <text
-                        x="30"
-                        y="10"
-                        fill="#000"
-                        fontSize="12px"
-                        fontWeight="bold"
-                        textAnchor="start"
-                        alignmentBaseline="central"
-                      >
-                        Selection
-                      </text>
-                      <circle
-                        cx="10"
-                        cy="30"
-                        r={circleRadius}
-                        stroke="#bbb"
-                        fill="none"
-                      />
-                      <text
-                        x="30"
-                        y="30"
-                        fill="#777"
-                        fontSize="10px"
-                        textAnchor="start"
-                        alignmentBaseline="central"
-                      >
-                        Neighbour of selection
-                      </text>
-                      <circle
-                        cx="10"
-                        cy="50"
-                        r={circleRadius}
-                        stroke="#bbb"
-                        fill="none"
-                      />
-                      <text
-                        x="30"
-                        y="50"
-                        fill="#ddd"
-                        fontSize="10px"
-                        textAnchor="start"
-                        alignmentBaseline="central"
-                      >
-                        Not a neighbour of selection
-                      </text>
-                    </g>
-                    {selectedUniprotIds.length > 0 ? (
-                      <g
-                        fill="none"
-                        stroke="#999"
-                        strokeOpacity={0.6}
-                        transform={`translate(${width / 2},${height / 2})`}
-                      >
-                        {(selectedUniprotIds.length === 1
-                          ? edgesFilteredWithoutSelectedUniprotIds
-                          : edgesFilteredWithinSelectedUniprotIds
-                        ).map(e => {
-                          let fromAngle = nodeToAngleRad(e.source) + 0.001;
-                          let toAngle = nodeToAngleRad(e.target) + 0.001;
-                          let fromX =
-                            ((diameter - circleRadius) / 2) *
-                            Math.sin(fromAngle);
-                          let fromY =
-                            (-(diameter - circleRadius) / 2) *
-                            Math.cos(fromAngle);
-                          let toX =
-                            ((diameter - circleRadius) / 2) * Math.sin(toAngle);
-                          let toY =
-                            (-(diameter - circleRadius) / 2) *
-                            Math.cos(toAngle);
-                          const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                          return <path d={d} />;
-                        })}
-                      </g>
-                    ) : (
-                      <g
-                        fill="none"
-                        stroke="#999"
-                        strokeOpacity={0.6}
-                        transform={`translate(${width / 2},${height / 2})`}
-                      >
-                        {edgesFiltered.map(e => {
-                          let fromAngle = nodeToAngleRad(e.source) + 0.001;
-                          let toAngle = nodeToAngleRad(e.target) + 0.001;
-                          let fromX =
-                            ((diameter - circleRadius) / 2) *
-                            Math.sin(fromAngle);
-                          let fromY =
-                            (-(diameter - circleRadius) / 2) *
-                            Math.cos(fromAngle);
-                          let toX =
-                            ((diameter - circleRadius) / 2) * Math.sin(toAngle);
-                          let toY =
-                            (-(diameter - circleRadius) / 2) *
-                            Math.cos(toAngle);
-                          const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                          return <path d={d} />;
-                        })}
-                      </g>
-                    )}
-                    <g
-                      style={{ font: '10px sans-serif' }}
-                      transform={`translate(${width / 2},${height / 2})`}
-                    >
-                      {nodes.map(n => {
-                        const { isSelected, isNeighbourOfSelected } = n;
-                        const angleRad = nodeToAngleRad(n.uniprotId);
-                        const angleDeg = nodeToAngleDeg(n.uniprotId);
-                        const isRightHalf = isInRightSemiCircle(n.uniprotId);
-                        return (
-                          <g
-                            key={n.uniprotId}
-                            transform={`translate(${textRadius *
-                              Math.sin(angleRad)},${-textRadius *
-                              Math.cos(angleRad)})`}
-                            onClick={() => this.handleProteinClick(n.uniprotId)}
-                          >
-                            <circle
-                              cx="0"
-                              cy="0"
-                              r={circleRadius}
-                              fill={nodeToColour(n)}
-                              stroke={isSelected ? '#000' : '#bbb'}
-                              strokeWidth={isSelected ? 2 : 1}
-                              style={{ cursor: 'pointer' }}
-                            />
-                            <text
-                              x="0"
-                              y="0"
-                              style={{ cursor: 'pointer' }}
-                              fill={
-                                selectedUniprotIds.length > 0
-                                  ? isSelected
-                                    ? '#000'
-                                    : isNeighbourOfSelected
-                                    ? '#777'
-                                    : '#ddd'
-                                  : '#777'
-                              }
-                              fontSize={isSelected ? '12px' : null}
-                              fontWeight={isSelected ? 'bold' : null}
-                              textAnchor={isRightHalf ? 'start' : 'end'}
-                              alignmentBaseline="central"
-                              transform={`rotate(${(isRightHalf ? 270 : 90) +
-                                angleDeg}) translate(${
-                                isRightHalf ? textOffset : -textOffset
-                              }, 0)`}
-                            >
-                              {n.symbol} (
-                              {selectedUniprotIds.length > 0
-                                ? selectedUniprotIds.length === 1
-                                  ? n.neighbourCountWithinOrWithout
-                                  : n.neighbourCountWithin
-                                : n.neighbourCount}
-                              )
-                            </text>
-                          </g>
-                        );
-                      })}
-                    </g>
-                  </svg>
-                </div>
+              <Grid
+                id="interaction-plot-container"
+                item
+                sm={12}
+                md={6}
+                onMouseLeave={() => this.handleMouseLeave()}
+              >
+                <ListTooltip
+                  open={tooltip.open}
+                  anchorEl={tooltip.anchorEl}
+                  dataList={tooltip.data ? tooltip.data : []}
+                  container={document.getElementById(
+                    'interaction-plot-container'
+                  )}
+                />
+
+                <InteractionsPlot
+                  {...{
+                    nodes,
+                    selectedUniprotIds,
+                    edgesFiltered,
+                    edgesFilteredWithinSelectedUniprotIds,
+                    edgesFilteredWithoutSelectedUniprotIds,
+                    handleProteinClick: this.handleProteinClick,
+                    handleMouseOver: this.handleMouseOver,
+                  }}
+                />
               </Grid>
             </Grid>
           );
@@ -676,6 +477,4 @@ class ProteinInteractionsDetail extends React.Component {
   }
 }
 
-export default withContentRect('bounds')(
-  withStyles(styles)(ProteinInteractionsDetail)
-);
+export default withStyles(styles)(ProteinInteractionsDetail);

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -132,38 +132,50 @@ class ProteinInteractionsDetail extends React.Component {
   };
   handleMouseOver = d => {
     const { classes } = this.props;
+    const { interactionTypes } = this.state;
     const anchorEl = document.querySelector(`#node-${d.uniprotId}`);
     const data = [
       { label: 'Protein', value: d.symbol },
       {
-        label: 'Interactors',
+        label: 'Interactors (within selection)',
         value: d.interactorsCount,
       },
       {
-        label: 'Interactions by type',
+        label: 'Interactions by type (within selection)',
         value: (
           <React.Fragment>
-            <Chip
-              className={classNames(
-                classes.chipSource,
-                classes.chipSourceEnzymeSubstrate
-              )}
-              label={`Enzyme-substrate (${d.interactionsEnzymeSubstrateCount})`}
-              color={sourceTypeColors.enzymeSubstrate}
-            />
-            <Chip
-              className={classNames(
-                classes.chipSource,
-                classes.chipSourcePathways
-              )}
-              label={`Pathways (${d.interactionsPathwaysCount})`}
-              color={sourceTypeColors.pathways}
-            />
-            <Chip
-              className={classNames(classes.chipSource, classes.chipSourcePPI)}
-              label={`PPI (${d.interactionsPPICount})`}
-              color={sourceTypeColors.ppi}
-            />
+            {interactionTypes.enzymeSubstrate ? (
+              <Chip
+                className={classNames(
+                  classes.chipSource,
+                  classes.chipSourceEnzymeSubstrate
+                )}
+                label={`Enzyme-substrate (${
+                  d.interactionsEnzymeSubstrateCount
+                })`}
+                color={sourceTypeColors.enzymeSubstrate}
+              />
+            ) : null}
+            {interactionTypes.pathways ? (
+              <Chip
+                className={classNames(
+                  classes.chipSource,
+                  classes.chipSourcePathways
+                )}
+                label={`Pathways (${d.interactionsPathwaysCount})`}
+                color={sourceTypeColors.pathways}
+              />
+            ) : null}
+            {interactionTypes.ppi ? (
+              <Chip
+                className={classNames(
+                  classes.chipSource,
+                  classes.chipSourcePPI
+                )}
+                label={`PPI (${d.interactionsPPICount})`}
+                color={sourceTypeColors.ppi}
+              />
+            ) : null}
           </React.Fragment>
         ),
       },

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -503,13 +503,7 @@ class ProteinInteractionsDetail extends React.Component {
                   }
                 />
               </Grid>
-              <Grid
-                id="interaction-plot-container"
-                item
-                sm={12}
-                md={6}
-                onMouseLeave={() => this.handleMouseLeave()}
-              >
+              <Grid id="interaction-plot-container" item sm={12} md={6}>
                 <ListTooltip
                   open={tooltip.open}
                   anchorEl={tooltip.anchorEl}
@@ -528,6 +522,7 @@ class ProteinInteractionsDetail extends React.Component {
                     edgesFilteredWithoutSelectedUniprotIds,
                     handleProteinClick: this.handleProteinClick,
                     handleMouseOver: this.handleMouseOver,
+                    handleMouseLeave: this.handleMouseLeave,
                   }}
                 />
               </Grid>

--- a/src/components/ProteinInteractions/Detail.js
+++ b/src/components/ProteinInteractions/Detail.js
@@ -13,8 +13,9 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
 import Chip from '@material-ui/core/Chip';
+import Paper from '@material-ui/core/Paper';
 
-import { Link, OtTableRF, PALETTE } from 'ot-ui';
+import { Button, Link, OtTableRF, PALETTE } from 'ot-ui';
 
 const query = gql`
   query ProteinInteractionsQuery($ensgId: String!) {
@@ -52,7 +53,8 @@ const sourceTypeColors = {
 
 const styles = theme => ({
   formControl: {
-    margin: theme.spacing.unit * 3,
+    margin: theme.spacing.unit * 0.5,
+    marginLeft: theme.spacing.unit * 2,
   },
   chip: {
     margin: theme.spacing.unit * 0.5,
@@ -261,6 +263,7 @@ class ProteinInteractionsDetail extends React.Component {
               <Grid item sm={12} md={6}>
                 <div>
                   <Typography>Filter by interaction type</Typography>
+
                   <FormControl
                     component="fieldset"
                     className={classes.formControl}
@@ -326,16 +329,39 @@ class ProteinInteractionsDetail extends React.Component {
                     </FormGroup>
                   </FormControl>
                 </div>
+                <br />
                 <Typography>Selection</Typography>
-                {selectedUniprotIds.map(uniprotId => (
-                  <Chip
-                    key={uniprotId}
-                    className={classes.chip}
-                    color="primary"
-                    label={nodes.find(n => n.uniprotId === uniprotId).symbol}
-                    onDelete={() => this.handleProteinClick(uniprotId)}
-                  />
-                ))}
+
+                {selectedUniprotIds.length > 0 ? (
+                  <React.Fragment>
+                    {selectedUniprotIds.map(uniprotId => (
+                      <Chip
+                        key={uniprotId}
+                        className={classes.chip}
+                        color="primary"
+                        label={
+                          nodes.find(n => n.uniprotId === uniprotId).symbol
+                        }
+                        onDelete={() => this.handleProteinClick(uniprotId)}
+                      />
+                    ))}
+                    {selectedUniprotIds.length > 1 ? (
+                      <Button color="primary" size="small" disableRipple>
+                        Analyse with batch search
+                      </Button>
+                    ) : null}
+                  </React.Fragment>
+                ) : (
+                  <Typography align="center" style={{ padding: '4px' }}>
+                    <i>
+                      No selection. Click on proteins on the chart to make a
+                      selection.
+                    </i>
+                  </Typography>
+                )}
+
+                <br />
+                <br />
                 <Typography>Interaction details</Typography>
                 <OtTableRF
                   columns={[

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -1,13 +1,21 @@
 import React from 'react';
+import { findDOMNode } from 'react-dom';
 import { withContentRect } from 'react-measure';
 import * as d3 from 'd3';
 
+import { Button, downloadSVG } from 'ot-ui';
+
 class InteractionsPlot extends React.Component {
   state = {};
+  svgContainer = React.createRef();
   static getDerivedStateFromProps(props) {
     const { width = 600 } = props.contentRect.bounds;
     return { width };
   }
+  handleSVGDownload = (svgContainer, filenameStem) => {
+    const svgNode = findDOMNode(svgContainer.current).querySelector('svg');
+    downloadSVG({ svgNode, filenameStem });
+  };
   render() {
     const {
       measureRef,
@@ -19,6 +27,7 @@ class InteractionsPlot extends React.Component {
       handleProteinClick,
       handleMouseOver,
       handleMouseLeave,
+      filenameStem,
     } = this.props;
     const { width } = this.state;
     const height = Math.min(width, 700);
@@ -62,209 +71,221 @@ class InteractionsPlot extends React.Component {
 
     return (
       <div ref={measureRef}>
-        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>
-          <g
-            transform={`translate(${width -
-              20 * (legendData.length + 3)},${20})`}
-          >
-            <text
-              x={-10}
-              y={10}
-              fontSize="12px"
-              fill="#777"
-              textAnchor="end"
-              alignmentBaseline="central"
+        <Button
+          variant="outlined"
+          onClick={() => {
+            this.handleSVGDownload(this.svgContainer, filenameStem);
+          }}
+        >
+          SVG
+        </Button>
+        <div ref={this.svgContainer}>
+          <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>
+            <g
+              transform={`translate(${width -
+                20 * (legendData.length + 3)},${20})`}
             >
-              {0}
-            </text>
-            {legendData.map((d, i) => (
-              <rect
-                key={i}
-                x={i * 20}
-                y={0}
-                width={20}
-                height={20}
-                fill={colour(d + 1)}
-                stroke="#777"
+              <text
+                x={-10}
+                y={10}
+                fontSize="12px"
+                fill="#777"
+                textAnchor="end"
+                alignmentBaseline="central"
+              >
+                {0}
+              </text>
+              {legendData.map((d, i) => (
+                <rect
+                  key={i}
+                  x={i * 20}
+                  y={0}
+                  width={20}
+                  height={20}
+                  fill={colour(d + 1)}
+                  stroke="#777"
+                />
+              ))}
+              <text
+                x={legendData.length * 20 + 10}
+                y={10}
+                fontSize="12px"
+                fill="#777"
+                textAnchor="start"
+                alignmentBaseline="central"
+              >
+                {maxNeighbourCount}
+              </text>
+              <text
+                x={(legendData.length * 20) / 2}
+                y={30}
+                fontSize="12px"
+                fill="#777"
+                textAnchor="middle"
+                alignmentBaseline="central"
+              >
+                Interactions (ignoring selection)
+              </text>
+            </g>
+            <g transform={`translate(${20},${20})`}>
+              <circle
+                cx="10"
+                cy="10"
+                r={circleRadius}
+                stroke="#000"
+                strokeWidth="2"
+                fill="none"
               />
-            ))}
-            <text
-              x={legendData.length * 20 + 10}
-              y={10}
-              fontSize="12px"
-              fill="#777"
-              textAnchor="start"
-              alignmentBaseline="central"
-            >
-              {maxNeighbourCount}
-            </text>
-            <text
-              x={(legendData.length * 20) / 2}
-              y={30}
-              fontSize="12px"
-              fill="#777"
-              textAnchor="middle"
-              alignmentBaseline="central"
-            >
-              Interactions (ignoring selection)
-            </text>
-          </g>
-          <g transform={`translate(${20},${20})`}>
-            <circle
-              cx="10"
-              cy="10"
-              r={circleRadius}
-              stroke="#000"
-              strokeWidth="2"
-              fill="none"
-            />
-            <text
-              x="30"
-              y="10"
-              fill="#000"
-              fontSize="12px"
-              fontWeight="bold"
-              textAnchor="start"
-              alignmentBaseline="central"
-            >
-              Selection
-            </text>
-            <circle
-              cx="10"
-              cy="30"
-              r={circleRadius}
-              stroke="#bbb"
-              fill="none"
-            />
-            <text
-              x="30"
-              y="30"
-              fill="#777"
-              fontSize="12px"
-              textAnchor="start"
-              alignmentBaseline="central"
-            >
-              Interaction with selection
-            </text>
-            <circle
-              cx="10"
-              cy="50"
-              r={circleRadius}
-              stroke="#bbb"
-              fill="none"
-            />
-            <text
-              x="30"
-              y="50"
-              fill="#ddd"
-              fontSize="12px"
-              textAnchor="start"
-              alignmentBaseline="central"
-            >
-              No interaction with selection
-            </text>
-          </g>
-          {selectedUniprotIds.length > 0 ? (
+              <text
+                x="30"
+                y="10"
+                fill="#000"
+                fontSize="12px"
+                fontWeight="bold"
+                textAnchor="start"
+                alignmentBaseline="central"
+              >
+                Selection
+              </text>
+              <circle
+                cx="10"
+                cy="30"
+                r={circleRadius}
+                stroke="#bbb"
+                fill="none"
+              />
+              <text
+                x="30"
+                y="30"
+                fill="#777"
+                fontSize="12px"
+                textAnchor="start"
+                alignmentBaseline="central"
+              >
+                Interaction with selection
+              </text>
+              <circle
+                cx="10"
+                cy="50"
+                r={circleRadius}
+                stroke="#bbb"
+                fill="none"
+              />
+              <text
+                x="30"
+                y="50"
+                fill="#ddd"
+                fontSize="12px"
+                textAnchor="start"
+                alignmentBaseline="central"
+              >
+                No interaction with selection
+              </text>
+            </g>
+            {selectedUniprotIds.length > 0 ? (
+              <g
+                fill="none"
+                stroke="#999"
+                strokeOpacity={0.6}
+                transform={`translate(${width / 2},${height / 2})`}
+              >
+                {(selectedUniprotIds.length === 1
+                  ? edgesFilteredWithoutSelectedUniprotIds
+                  : edgesFilteredWithinSelectedUniprotIds
+                ).map(e => {
+                  let fromAngle = nodeToAngleRad(e.source) + 0.001;
+                  let toAngle = nodeToAngleRad(e.target) + 0.001;
+                  let fromX =
+                    ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
+                  let fromY =
+                    (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
+                  let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
+                  let toY =
+                    (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
+                  const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
+                  return <path key={`${e.source}-${e.target}`} d={d} />;
+                })}
+              </g>
+            ) : (
+              <g
+                fill="none"
+                stroke="#999"
+                strokeOpacity={0.6}
+                transform={`translate(${width / 2},${height / 2})`}
+              >
+                {edgesFiltered.map(e => {
+                  let fromAngle = nodeToAngleRad(e.source) + 0.001;
+                  let toAngle = nodeToAngleRad(e.target) + 0.001;
+                  let fromX =
+                    ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
+                  let fromY =
+                    (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
+                  let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
+                  let toY =
+                    (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
+                  const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
+                  return <path key={`${e.source}-${e.target}`} d={d} />;
+                })}
+              </g>
+            )}
             <g
-              fill="none"
-              stroke="#999"
-              strokeOpacity={0.6}
+              style={{ font: '10px sans-serif' }}
               transform={`translate(${width / 2},${height / 2})`}
             >
-              {(selectedUniprotIds.length === 1
-                ? edgesFilteredWithoutSelectedUniprotIds
-                : edgesFilteredWithinSelectedUniprotIds
-              ).map(e => {
-                let fromAngle = nodeToAngleRad(e.source) + 0.001;
-                let toAngle = nodeToAngleRad(e.target) + 0.001;
-                let fromX =
-                  ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
-                let fromY =
-                  (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
-                let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
-                let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
-                const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                return <path key={`${e.source}-${e.target}`} d={d} />;
-              })}
-            </g>
-          ) : (
-            <g
-              fill="none"
-              stroke="#999"
-              strokeOpacity={0.6}
-              transform={`translate(${width / 2},${height / 2})`}
-            >
-              {edgesFiltered.map(e => {
-                let fromAngle = nodeToAngleRad(e.source) + 0.001;
-                let toAngle = nodeToAngleRad(e.target) + 0.001;
-                let fromX =
-                  ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
-                let fromY =
-                  (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
-                let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
-                let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
-                const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                return <path key={`${e.source}-${e.target}`} d={d} />;
-              })}
-            </g>
-          )}
-          <g
-            style={{ font: '10px sans-serif' }}
-            transform={`translate(${width / 2},${height / 2})`}
-          >
-            {nodes.map(n => {
-              const { isSelected, isNeighbourOfSelected } = n;
-              const angleRad = nodeToAngleRad(n.uniprotId);
-              const angleDeg = nodeToAngleDeg(n.uniprotId);
-              const isRightHalf = isInRightSemiCircle(n.uniprotId);
-              return (
-                <g
-                  key={n.uniprotId}
-                  id={`node-${n.uniprotId}`}
-                  transform={`translate(${textRadius *
-                    Math.sin(angleRad)},${-textRadius * Math.cos(angleRad)})`}
-                  onClick={() => handleProteinClick(n.uniprotId)}
-                  onMouseMove={() => handleMouseOver(n)}
-                  onMouseLeave={() => handleMouseLeave()}
-                >
-                  <circle
-                    cx="0"
-                    cy="0"
-                    r={circleRadius}
-                    fill={nodeToColour(n)}
-                    stroke={isSelected ? '#000' : '#bbb'}
-                    strokeWidth={isSelected ? 2 : 1}
-                    style={{ cursor: 'pointer' }}
-                  />
-                  <text
-                    x="0"
-                    y="0"
-                    style={{ cursor: 'pointer' }}
-                    fill={
-                      selectedUniprotIds.length > 0
-                        ? isSelected
-                          ? '#000'
-                          : isNeighbourOfSelected
-                          ? '#777'
-                          : '#ddd'
-                        : '#777'
-                    }
-                    fontSize={isSelected ? '12px' : null}
-                    fontWeight={isSelected ? 'bold' : null}
-                    textAnchor={isRightHalf ? 'start' : 'end'}
-                    alignmentBaseline="central"
-                    transform={`rotate(${(isRightHalf ? 270 : 90) +
-                      angleDeg}) translate(${
-                      isRightHalf ? textOffset : -textOffset
-                    }, 0)`}
+              {nodes.map(n => {
+                const { isSelected, isNeighbourOfSelected } = n;
+                const angleRad = nodeToAngleRad(n.uniprotId);
+                const angleDeg = nodeToAngleDeg(n.uniprotId);
+                const isRightHalf = isInRightSemiCircle(n.uniprotId);
+                return (
+                  <g
+                    key={n.uniprotId}
+                    id={`node-${n.uniprotId}`}
+                    transform={`translate(${textRadius *
+                      Math.sin(angleRad)},${-textRadius * Math.cos(angleRad)})`}
+                    onClick={() => handleProteinClick(n.uniprotId)}
+                    onMouseMove={() => handleMouseOver(n)}
+                    onMouseLeave={() => handleMouseLeave()}
                   >
-                    {n.symbol}
-                  </text>
-                </g>
-              );
-            })}
-          </g>
-        </svg>
+                    <circle
+                      cx="0"
+                      cy="0"
+                      r={circleRadius}
+                      fill={nodeToColour(n)}
+                      stroke={isSelected ? '#000' : '#bbb'}
+                      strokeWidth={isSelected ? 2 : 1}
+                      style={{ cursor: 'pointer' }}
+                    />
+                    <text
+                      x="0"
+                      y="0"
+                      style={{ cursor: 'pointer' }}
+                      fill={
+                        selectedUniprotIds.length > 0
+                          ? isSelected
+                            ? '#000'
+                            : isNeighbourOfSelected
+                            ? '#777'
+                            : '#ddd'
+                          : '#777'
+                      }
+                      fontSize={isSelected ? '12px' : null}
+                      fontWeight={isSelected ? 'bold' : null}
+                      textAnchor={isRightHalf ? 'start' : 'end'}
+                      alignmentBaseline="central"
+                      transform={`rotate(${(isRightHalf ? 270 : 90) +
+                        angleDeg}) translate(${
+                        isRightHalf ? textOffset : -textOffset
+                      }, 0)`}
+                    >
+                      {n.symbol}
+                    </text>
+                  </g>
+                );
+              })}
+            </g>
+          </svg>
+        </div>
       </div>
     );
   }

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -1,0 +1,264 @@
+import React from 'react';
+import { withContentRect } from 'react-measure';
+import * as d3 from 'd3';
+
+class InteractionsPlot extends React.Component {
+  state = {};
+  static getDerivedStateFromProps(props) {
+    const { width = 600 } = props.contentRect.bounds;
+    return { width };
+  }
+  render() {
+    const {
+      measureRef,
+      nodes,
+      selectedUniprotIds,
+      edgesFiltered,
+      edgesFilteredWithinSelectedUniprotIds,
+      edgesFilteredWithoutSelectedUniprotIds,
+      handleProteinClick,
+      handleMouseOver,
+    } = this.props;
+    const { width } = this.state;
+    const height = Math.min(width, 700);
+
+    // helpers
+    const padding = 100;
+    const radius = height / 2 - padding;
+    const diameter = 2 * radius;
+    const textOffset = 10;
+    const textRadius = radius + textOffset;
+    const circleRadius = 4;
+    const colour = d3
+      .scaleLog()
+      .domain(d3.extent(nodes, n => n.neighbourCount + 1))
+      .range(['#fff', '#3489ca']);
+
+    // order alphabetically
+    const nodeCount = nodes.length;
+    const uniprotIdToIndex = new Map(
+      nodes
+        .sort((a, b) => d3.ascending(a.symbol, b.symbol))
+        .map((d, i) => [d.uniprotId, i])
+    );
+    const nodeToAngleRad = n =>
+      (2 * Math.PI * uniprotIdToIndex.get(n)) / nodeCount;
+    const nodeToAngleDeg = n => (360 * uniprotIdToIndex.get(n)) / nodeCount;
+    const nodeToColour = n => colour(n.neighbourCount + 1);
+    const isInRightSemiCircle = n => uniprotIdToIndex.get(n) / nodeCount < 0.5;
+
+    // legend data for scale
+    const maxNeighbourCount = d3.max(nodes, n => n.neighbourCount);
+    const legendInterval = maxNeighbourCount / 5;
+    const legendData = [
+      0,
+      legendInterval,
+      legendInterval * 2,
+      legendInterval * 3,
+      legendInterval * 4,
+      legendInterval * 5,
+    ];
+
+    return (
+      <div ref={measureRef}>
+        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>
+          <g
+            transform={`translate(${width -
+              20 * (legendData.length + 3)},${20})`}
+          >
+            <text
+              x={-10}
+              y={10}
+              fill="#bbb"
+              textAnchor="end"
+              alignmentBaseline="central"
+            >
+              {0}
+            </text>
+            {legendData.map((d, i) => (
+              <rect
+                x={i * 20}
+                y={0}
+                width={20}
+                height={20}
+                fill={colour(d + 1)}
+                stroke="#bbb"
+              />
+            ))}
+            <text
+              x={legendData.length * 20 + 10}
+              y={10}
+              fill="#bbb"
+              textAnchor="start"
+              alignmentBaseline="central"
+            >
+              {maxNeighbourCount}
+            </text>
+          </g>
+          <g transform={`translate(${20},${20})`}>
+            <circle
+              cx="10"
+              cy="10"
+              r={circleRadius}
+              stroke="#000"
+              strokeWidth="2"
+              fill="none"
+            />
+            <text
+              x="30"
+              y="10"
+              fill="#000"
+              fontSize="12px"
+              fontWeight="bold"
+              textAnchor="start"
+              alignmentBaseline="central"
+            >
+              Selection
+            </text>
+            <circle
+              cx="10"
+              cy="30"
+              r={circleRadius}
+              stroke="#bbb"
+              fill="none"
+            />
+            <text
+              x="30"
+              y="30"
+              fill="#777"
+              fontSize="10px"
+              textAnchor="start"
+              alignmentBaseline="central"
+            >
+              Neighbour of selection
+            </text>
+            <circle
+              cx="10"
+              cy="50"
+              r={circleRadius}
+              stroke="#bbb"
+              fill="none"
+            />
+            <text
+              x="30"
+              y="50"
+              fill="#ddd"
+              fontSize="10px"
+              textAnchor="start"
+              alignmentBaseline="central"
+            >
+              Not a neighbour of selection
+            </text>
+          </g>
+          {selectedUniprotIds.length > 0 ? (
+            <g
+              fill="none"
+              stroke="#999"
+              strokeOpacity={0.6}
+              transform={`translate(${width / 2},${height / 2})`}
+            >
+              {(selectedUniprotIds.length === 1
+                ? edgesFilteredWithoutSelectedUniprotIds
+                : edgesFilteredWithinSelectedUniprotIds
+              ).map(e => {
+                let fromAngle = nodeToAngleRad(e.source) + 0.001;
+                let toAngle = nodeToAngleRad(e.target) + 0.001;
+                let fromX =
+                  ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
+                let fromY =
+                  (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
+                let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
+                let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
+                const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
+                return <path d={d} />;
+              })}
+            </g>
+          ) : (
+            <g
+              fill="none"
+              stroke="#999"
+              strokeOpacity={0.6}
+              transform={`translate(${width / 2},${height / 2})`}
+            >
+              {edgesFiltered.map(e => {
+                let fromAngle = nodeToAngleRad(e.source) + 0.001;
+                let toAngle = nodeToAngleRad(e.target) + 0.001;
+                let fromX =
+                  ((diameter - circleRadius) / 2) * Math.sin(fromAngle);
+                let fromY =
+                  (-(diameter - circleRadius) / 2) * Math.cos(fromAngle);
+                let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
+                let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
+                const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
+                return <path d={d} />;
+              })}
+            </g>
+          )}
+          <g
+            style={{ font: '10px sans-serif' }}
+            transform={`translate(${width / 2},${height / 2})`}
+          >
+            {nodes.map(n => {
+              const { isSelected, isNeighbourOfSelected } = n;
+              const angleRad = nodeToAngleRad(n.uniprotId);
+              const angleDeg = nodeToAngleDeg(n.uniprotId);
+              const isRightHalf = isInRightSemiCircle(n.uniprotId);
+              return (
+                <g
+                  key={n.uniprotId}
+                  id={`node-${n.uniprotId}`}
+                  transform={`translate(${textRadius *
+                    Math.sin(angleRad)},${-textRadius * Math.cos(angleRad)})`}
+                  onClick={() => handleProteinClick(n.uniprotId)}
+                  onMouseOver={() => handleMouseOver(n)}
+                >
+                  <circle
+                    cx="0"
+                    cy="0"
+                    r={circleRadius}
+                    fill={nodeToColour(n)}
+                    stroke={isSelected ? '#000' : '#bbb'}
+                    strokeWidth={isSelected ? 2 : 1}
+                    style={{ cursor: 'pointer' }}
+                  />
+                  <text
+                    x="0"
+                    y="0"
+                    style={{ cursor: 'pointer' }}
+                    fill={
+                      selectedUniprotIds.length > 0
+                        ? isSelected
+                          ? '#000'
+                          : isNeighbourOfSelected
+                          ? '#777'
+                          : '#ddd'
+                        : '#777'
+                    }
+                    fontSize={isSelected ? '12px' : null}
+                    fontWeight={isSelected ? 'bold' : null}
+                    textAnchor={isRightHalf ? 'start' : 'end'}
+                    alignmentBaseline="central"
+                    transform={`rotate(${(isRightHalf ? 270 : 90) +
+                      angleDeg}) translate(${
+                      isRightHalf ? textOffset : -textOffset
+                    }, 0)`}
+                  >
+                    {n.symbol} (
+                    {selectedUniprotIds.length > 0
+                      ? selectedUniprotIds.length === 1
+                        ? n.neighbourCountWithinOrWithout
+                        : n.neighbourCountWithin
+                      : n.neighbourCount}
+                    )
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    );
+  }
+}
+
+export default withContentRect('bounds')(InteractionsPlot);

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -77,6 +77,7 @@ class InteractionsPlot extends React.Component {
             </text>
             {legendData.map((d, i) => (
               <rect
+                key={i}
                 x={i * 20}
                 y={0}
                 width={20}
@@ -170,7 +171,7 @@ class InteractionsPlot extends React.Component {
                 let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
                 let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
                 const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                return <path d={d} />;
+                return <path key={`${e.source}-${e.target}`} d={d} />;
               })}
             </g>
           ) : (
@@ -243,13 +244,7 @@ class InteractionsPlot extends React.Component {
                       isRightHalf ? textOffset : -textOffset
                     }, 0)`}
                   >
-                    {n.symbol} (
-                    {selectedUniprotIds.length > 0
-                      ? selectedUniprotIds.length === 1
-                        ? n.neighbourCountWithinOrWithout
-                        : n.neighbourCountWithin
-                      : n.neighbourCount}
-                    )
+                    {n.symbol}
                   </text>
                 </g>
               );

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -192,7 +192,7 @@ class InteractionsPlot extends React.Component {
                 let toX = ((diameter - circleRadius) / 2) * Math.sin(toAngle);
                 let toY = (-(diameter - circleRadius) / 2) * Math.cos(toAngle);
                 const d = `M${fromX},${fromY} Q0,0 ${toX},${toY}`;
-                return <path d={d} />;
+                return <path key={`${e.source}-${e.target}`} d={d} />;
               })}
             </g>
           )}

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -18,6 +18,7 @@ class InteractionsPlot extends React.Component {
       edgesFilteredWithoutSelectedUniprotIds,
       handleProteinClick,
       handleMouseOver,
+      handleMouseLeave,
     } = this.props;
     const { width } = this.state;
     const height = Math.min(width, 700);
@@ -211,7 +212,8 @@ class InteractionsPlot extends React.Component {
                   transform={`translate(${textRadius *
                     Math.sin(angleRad)},${-textRadius * Math.cos(angleRad)})`}
                   onClick={() => handleProteinClick(n.uniprotId)}
-                  onMouseOver={() => handleMouseOver(n)}
+                  onMouseMove={() => handleMouseOver(n)}
+                  onMouseLeave={() => handleMouseLeave()}
                 >
                   <circle
                     cx="0"

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -70,7 +70,8 @@ class InteractionsPlot extends React.Component {
             <text
               x={-10}
               y={10}
-              fill="#bbb"
+              fontSize="12px"
+              fill="#777"
               textAnchor="end"
               alignmentBaseline="central"
             >
@@ -84,17 +85,28 @@ class InteractionsPlot extends React.Component {
                 width={20}
                 height={20}
                 fill={colour(d + 1)}
-                stroke="#bbb"
+                stroke="#777"
               />
             ))}
             <text
               x={legendData.length * 20 + 10}
               y={10}
-              fill="#bbb"
+              fontSize="12px"
+              fill="#777"
               textAnchor="start"
               alignmentBaseline="central"
             >
               {maxNeighbourCount}
+            </text>
+            <text
+              x={(legendData.length * 20) / 2}
+              y={30}
+              fontSize="12px"
+              fill="#777"
+              textAnchor="middle"
+              alignmentBaseline="central"
+            >
+              Interactions (ignoring selection)
             </text>
           </g>
           <g transform={`translate(${20},${20})`}>
@@ -128,11 +140,11 @@ class InteractionsPlot extends React.Component {
               x="30"
               y="30"
               fill="#777"
-              fontSize="10px"
+              fontSize="12px"
               textAnchor="start"
               alignmentBaseline="central"
             >
-              Neighbour of selection
+              Interaction with selection
             </text>
             <circle
               cx="10"
@@ -145,11 +157,11 @@ class InteractionsPlot extends React.Component {
               x="30"
               y="50"
               fill="#ddd"
-              fontSize="10px"
+              fontSize="12px"
               textAnchor="start"
               alignmentBaseline="central"
             >
-              Not a neighbour of selection
+              No interaction with selection
             </text>
           </g>
           {selectedUniprotIds.length > 0 ? (

--- a/src/components/ProteinInteractions/InteractionsPlot.js
+++ b/src/components/ProteinInteractions/InteractionsPlot.js
@@ -3,6 +3,8 @@ import { findDOMNode } from 'react-dom';
 import { withContentRect } from 'react-measure';
 import * as d3 from 'd3';
 
+import Typography from '@material-ui/core/Typography';
+
 import { Button, downloadSVG } from 'ot-ui';
 
 class InteractionsPlot extends React.Component {
@@ -71,14 +73,19 @@ class InteractionsPlot extends React.Component {
 
     return (
       <div ref={measureRef}>
-        <Button
-          variant="outlined"
-          onClick={() => {
-            this.handleSVGDownload(this.svgContainer, filenameStem);
-          }}
-        >
-          SVG
-        </Button>
+        <div style={{ float: 'right', marginRight: '12px' }}>
+          <Typography>
+            Download as{' '}
+            <Button
+              variant="outlined"
+              onClick={() => {
+                this.handleSVGDownload(this.svgContainer, filenameStem);
+              }}
+            >
+              SVG
+            </Button>
+          </Typography>
+        </div>
         <div ref={this.svgContainer}>
           <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>
             <g

--- a/src/components/ProteinInteractions/InteractionsTable.js
+++ b/src/components/ProteinInteractions/InteractionsTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Link, OtTableRF, ListTooltip, PALETTE } from 'ot-ui';
+import { Link, OtTableRF } from 'ot-ui';
 
 import SourceChip from './SourceChip';
 import { generateComparatorFromAccessor } from '../../utils/comparators';

--- a/src/components/ProteinInteractions/InteractionsTable.js
+++ b/src/components/ProteinInteractions/InteractionsTable.js
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { Link, OtTableRF, ListTooltip, PALETTE } from 'ot-ui';
+
+import SourceChip from './SourceChip';
+
+const columns = interactionTypes => [
+  {
+    id: 'source',
+    label: 'Source',
+    renderCell: d => {
+      const { ensgId, symbol } = d.sourceNode;
+      return <Link to={`target/${ensgId}`}>{symbol}</Link>;
+    },
+  },
+  {
+    id: 'target',
+    label: 'Target',
+    renderCell: d => {
+      const { ensgId, symbol } = d.targetNode;
+      return <Link to={`target/${ensgId}`}>{symbol}</Link>;
+    },
+  },
+  {
+    id: 'sources',
+    label: 'Sources',
+    renderCell: d => (
+      <React.Fragment>
+        {interactionTypes.enzymeSubstrate
+          ? d.enzymeSubstrateSources.map(s => (
+              <SourceChip sourceType="enzymeSubstrate" key={s} label={s} />
+            ))
+          : null}
+        {interactionTypes.pathways
+          ? d.pathwaysSources.map(s => (
+              <SourceChip sourceType="pathways" key={s} label={s} />
+            ))
+          : null}
+        {interactionTypes.ppi
+          ? d.ppiSources.map(s => (
+              <SourceChip sourceType="ppi" key={s} label={s} />
+            ))
+          : null}
+      </React.Fragment>
+    ),
+  },
+  {
+    id: 'pmIds',
+    label: 'Reference',
+    renderCell: d =>
+      d.pmIds.length > 0 ? (
+        <Link
+          external
+          to={`https://europepmc.org/search?query=${d.pmIds
+            .map(r => `EXT_ID:${r}`)
+            .join(' OR ')}`}
+        >
+          {d.pmIds.length} publication
+          {d.pmIds.length > 1 ? 's' : null}
+        </Link>
+      ) : null,
+  },
+];
+
+const InteractionsTable = ({ data, interactionTypes }) => (
+  <OtTableRF columns={columns(interactionTypes)} data={data} />
+);
+
+export default InteractionsTable;

--- a/src/components/ProteinInteractions/InteractionsTable.js
+++ b/src/components/ProteinInteractions/InteractionsTable.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link, OtTableRF, ListTooltip, PALETTE } from 'ot-ui';
 
 import SourceChip from './SourceChip';
+import { generateComparatorFromAccessor } from '../../utils/comparators';
 
 const columns = interactionTypes => [
   {
@@ -12,6 +13,7 @@ const columns = interactionTypes => [
       const { ensgId, symbol } = d.sourceNode;
       return <Link to={`target/${ensgId}`}>{symbol}</Link>;
     },
+    comparator: generateComparatorFromAccessor(d => d.sourceNode.symbol),
   },
   {
     id: 'target',
@@ -20,6 +22,7 @@ const columns = interactionTypes => [
       const { ensgId, symbol } = d.targetNode;
       return <Link to={`target/${ensgId}`}>{symbol}</Link>;
     },
+    comparator: generateComparatorFromAccessor(d => d.targetNode.symbol),
   },
   {
     id: 'sources',

--- a/src/components/ProteinInteractions/SourceCheckbox.js
+++ b/src/components/ProteinInteractions/SourceCheckbox.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+import { sourceTypeColors } from './SourceChip';
+
+const styles = theme => ({
+  checked: {},
+  pathways: {
+    '&$checked': {
+      color: sourceTypeColors.pathways,
+    },
+  },
+  ppi: {
+    '&$checked': {
+      color: sourceTypeColors.ppi,
+    },
+  },
+  enzymeSubstrate: {
+    '&$checked': {
+      color: sourceTypeColors.enzymeSubstrate,
+    },
+  },
+});
+
+const SourceCheckbox = ({ classes, sourceType, ...rest }) => (
+  <Checkbox
+    classes={{
+      root: classes[sourceType],
+      checked: classes.checked,
+    }}
+    {...rest}
+  />
+);
+
+export default withStyles(styles)(SourceCheckbox);

--- a/src/components/ProteinInteractions/SourceChip.js
+++ b/src/components/ProteinInteractions/SourceChip.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import classNames from 'classnames';
+import Chip from '@material-ui/core/Chip';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+import { PALETTE } from 'ot-ui';
+
+export const sourceTypeColors = {
+  enzymeSubstrate: PALETTE.red,
+  pathways: PALETTE.green,
+  ppi: PALETTE.purple,
+};
+
+const styles = theme => ({
+  chipSource: {
+    margin: '1px',
+    height: '24px',
+    color: 'white',
+  },
+  pathways: {
+    backgroundColor: sourceTypeColors.pathways,
+  },
+  ppi: {
+    backgroundColor: sourceTypeColors.ppi,
+  },
+  enzymeSubstrate: {
+    backgroundColor: sourceTypeColors.enzymeSubstrate,
+  },
+});
+
+const SourceChip = ({ classes, sourceType, label }) => (
+  <Chip
+    className={classNames(classes.chipSource, classes[sourceType])}
+    label={label}
+    color={sourceTypeColors[sourceType]}
+  />
+);
+
+export default withStyles(styles)(SourceChip);

--- a/src/components/ProteinInteractions/index.js
+++ b/src/components/ProteinInteractions/index.js
@@ -33,9 +33,7 @@ const ProteinInteractionsWidget = ({
     <Widget
       title="Protein interactions"
       detailUrlStem="protein-interactions"
-      detail={
-        <ProteinInteractionsDetail ensgId={ensgId} uniprotId={uniprotId} />
-      }
+      detail={<ProteinInteractionsDetail {...{ ensgId, uniprotId, symbol }} />}
       sources={sources}
       detailHeader={{
         title: `${symbol} - Protein Interactions`,

--- a/src/components/ProteinInteractions/index.js
+++ b/src/components/ProteinInteractions/index.js
@@ -22,6 +22,7 @@ const styles = theme => ({
 const ProteinInteractionsWidget = ({
   classes,
   ensgId,
+  uniprotId,
   symbol,
   proteinInteractions,
 }) => {
@@ -32,7 +33,9 @@ const ProteinInteractionsWidget = ({
     <Widget
       title="Protein interactions"
       detailUrlStem="protein-interactions"
-      detail={<ProteinInteractionsDetail ensgId={ensgId} />}
+      detail={
+        <ProteinInteractionsDetail ensgId={ensgId} uniprotId={uniprotId} />
+      }
       sources={sources}
       detailHeader={{
         title: `${symbol} - Protein Interactions`,

--- a/src/components/ProteinInteractions/index.js
+++ b/src/components/ProteinInteractions/index.js
@@ -39,7 +39,7 @@ const ProteinInteractionsWidget = ({
       sources={sources}
       detailHeader={{
         title: `${symbol} - Protein Interactions`,
-        description: `Summary of interactions for ${symbol} based on OmniPath DB data. When 2 targets are selected, details on the interaction (including publications) are shown.`,
+        description: `Summary of interactions for ${symbol} based on OmniPath DB data.`,
       }}
       hasData={hasData}
     >

--- a/src/components/ProteinInteractions/index.js
+++ b/src/components/ProteinInteractions/index.js
@@ -21,20 +21,22 @@ const styles = theme => ({
 
 const ProteinInteractionsWidget = ({
   classes,
+  ensgId,
   symbol,
   proteinInteractions,
 }) => {
-  const { ppi, pathways, enzymeSubstrate } = proteinInteractions;
+  const { ppi, pathways, enzymeSubstrate, sources } = proteinInteractions;
   const hasData = ppi > 0 || pathways > 0 || proteinInteractions > 0;
 
   return (
     <Widget
       title="Protein interactions"
       detailUrlStem="protein-interactions"
-      detail={<ProteinInteractionsDetail />}
+      detail={<ProteinInteractionsDetail ensgId={ensgId} />}
+      sources={sources}
       detailHeader={{
         title: `${symbol} - Protein Interactions`,
-        description: `Protein Interactions`,
+        description: `Summary of interactions for ${symbol} based on OmniPath DB data. When 2 targets are selected, details on the interaction (including publications) are shown.`,
       }}
       hasData={hasData}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -8425,9 +8425,9 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-ot-ui@^0.0.82:
-  version "0.0.82"
-  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.82.tgz#a2c8327e5da6d9a7f56f2efeef8cf65c25447a58"
+ot-ui@^0.0.85:
+  version "0.0.85"
+  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.85.tgz#9c9efc769d2bde11fd68843a66159c83be0a6a1f"
 
 p-defer@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds an updated version of the protein interactions viewer. It allows:
* selection of multiple proteins
* adds a table of interactions
* shows sources per interaction (grouped into the three categories used previously)
* shows publications per interaction
* adds a batch search button when 2 or more proteins are selected (which currently points nowhere; to be updated when we have batch search in the React app)
