### PR TITLE
Add related diseases section

### DIFF
--- a/src/public/disease/Profile.js
+++ b/src/public/disease/Profile.js
@@ -14,8 +14,18 @@ const summariesQuery = gql`
     disease(efoId: $efoId) {
       id
       name
+      summaries {
+        ${sections
+          .filter(s => s.summaryQuery)
+          .map(s => `...${s.id}Fragment`)
+          .join('\n')}
+      }
     }
   }
+  ${sections
+    .filter(s => s.summaryQuery)
+    .map(s => print(s.summaryQuery))
+    .join('\n')}
 `;
 
 class DiseaseProfile extends Component {

--- a/src/public/disease/sections/RelatedDiseases/Description.js
+++ b/src/public/disease/sections/RelatedDiseases/Description.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    TODO: Write a description component for <strong>{name}</strong>.
+    Diseases related to <strong>{name}</strong> based on shared target
+    associations.
   </React.Fragment>
 );
 

--- a/src/public/disease/sections/RelatedDiseases/Section.js
+++ b/src/public/disease/sections/RelatedDiseases/Section.js
@@ -1,9 +1,75 @@
 import React from 'react';
+import withStyles from '@material-ui/core/styles/withStyles';
 
-const Section = ({ name }) => (
-  <React.Fragment>
-    TODO: Write a section component for <strong>{name}</strong>.
-  </React.Fragment>
-);
+import { OtTableRF, Link } from 'ot-ui';
+
+import Intersection from '../../../common/Intersection';
+
+const styles = () => ({
+  container: {
+    width: '204px',
+    margin: '8px 0',
+  },
+});
+
+let SharedTargets = ({ d, classes }) => {
+  return (
+    <div className={classes.container}>
+      <Intersection
+        id={d.B.name}
+        a={d.targetCountANotB}
+        ab={d.targetCountAAndB}
+        b={d.targetCountBNotA}
+      />
+    </div>
+  );
+};
+
+SharedTargets = withStyles(styles)(SharedTargets);
+
+const columns = name => [
+  {
+    id: 'B.name',
+    label: 'Related disease',
+    renderCell: d => <Link to={`../${d.B.id}`}>{d.B.name}</Link>,
+    comparator: (a, b) => {
+      if (a.B.name <= b.B.name) {
+        return -1;
+      }
+      return 1;
+    },
+  },
+  {
+    id: 'targetCountAAndB',
+    label: 'Number of shared target associations',
+    renderCell: d => <SharedTargets d={d} />,
+  },
+  {
+    id: 'targetCountANotB',
+    label: `Targets associated with the related disease but not ${name}`,
+  },
+  {
+    id: 'targetCountBNotA',
+    label: `Targets associated with ${name} but not the related disease`,
+  },
+];
+
+const Section = ({ efoId, name, data }) => {
+  const { rows } = data;
+  const rowsMapped = rows.map(d => ({
+    ...d,
+    targetCountANotB: d.targetCountA - d.targetCountAAndB,
+    targetCountBNotA: d.targetCountB - d.targetCountAAndB,
+  }));
+
+  return (
+    <OtTableRF
+      loading={false}
+      error={false}
+      columns={columns(name)}
+      data={rowsMapped}
+    />
+  );
+};
 
 export default Section;

--- a/src/public/disease/sections/RelatedDiseases/Summary.js
+++ b/src/public/disease/sections/RelatedDiseases/Summary.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
-const Summary = ({ name }) => (
-  <React.Fragment>TODO: Write a summary</React.Fragment>
+const Summary = ({ relatedDiseasesCount }) => (
+  <React.Fragment>
+    {relatedDiseasesCount} diseases
+    <br />
+    (through shared targets)
+  </React.Fragment>
 );
 
 export default Summary;

--- a/src/public/disease/sections/RelatedDiseases/index.js
+++ b/src/public/disease/sections/RelatedDiseases/index.js
@@ -1,7 +1,13 @@
+import { loader } from 'graphql.macro';
+
 export const id = 'relatedDiseases';
 export const name = 'Related Diseases';
 
-export const hasSummaryData = () => true; // TODO: override this
+export const hasSummaryData = ({ relatedDiseasesCount }) =>
+  relatedDiseasesCount > 0;
+
+export const summaryQuery = loader('./summaryQuery.gql');
+export const sectionQuery = loader('./sectionQuery.gql');
 
 export { default as DescriptionComponent } from './Description';
 export { default as SummaryComponent } from './Summary';

--- a/src/public/disease/sections/RelatedDiseases/sectionQuery.gql
+++ b/src/public/disease/sections/RelatedDiseases/sectionQuery.gql
@@ -1,0 +1,23 @@
+query RelatedDiseasesQuery($efoId: String!) {
+  disease(efoId: $efoId) {
+    id
+    details {
+      relatedDiseases {
+        rows {
+          A {
+            id
+            name
+          }
+          B {
+            id
+            name
+          }
+          targetCountA
+          targetCountB
+          targetCountAAndB
+          targetCountAOrB
+        }
+      }
+    }
+  }
+}

--- a/src/public/disease/sections/RelatedDiseases/summaryQuery.gql
+++ b/src/public/disease/sections/RelatedDiseases/summaryQuery.gql
@@ -1,0 +1,9 @@
+fragment relatedDiseasesFragment on DiseaseSummaries {
+  relatedDiseases {
+    relatedDiseasesCount
+    sources {
+      name
+      url
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the related diseases section (dependent on some changes to the GraphQL API). It is very similar to the related targets section.