### PR TITLE
Use a linear Venn diagram

### DIFF
--- a/src/public/common/LinearVenn.js
+++ b/src/public/common/LinearVenn.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import withTheme from '@material-ui/core/styles/withTheme';
-import * as d3 from 'd3';
 
 const WIDTH = 400;
 const HEIGHT = 18;
@@ -13,18 +12,39 @@ const LinearVenn = ({ theme, aOnly, aAndB, bOnly, max }) => {
   const bOnlyStart = aAndBStart + aAndBWidth;
   const bOnlyWidth = (WIDTH * bOnly) / max;
 
-  const halfwayColour = d3.interpolateRgb(
-    d3.rgb(theme.palette.primary.main),
-    d3.rgb(theme.palette.secondary.main)
-  )(0.5);
-
   return (
     <svg width={WIDTH} height={HEIGHT}>
+      <defs>
+        <pattern
+          id="diagonalHatch"
+          width="4"
+          height="4"
+          patternTransform="rotate(45 0 0)"
+          patternUnits="userSpaceOnUse"
+        >
+          <line
+            x1="1"
+            y1="0"
+            x2="1"
+            y2="4"
+            strokeWidth="2"
+            stroke={theme.palette.primary.main}
+          />
+          <line
+            x1="3"
+            y1="0"
+            x2="3"
+            y2="4"
+            strokeWidth="2"
+            stroke={theme.palette.secondary.main}
+          />
+        </pattern>
+      </defs>
       <g>
         <rect
           x={aOnlyStart}
           y={0}
-          width={aOnlyWidth + aAndBWidth}
+          width={aOnlyWidth}
           height={HEIGHT}
           fill={theme.palette.primary.main}
           stroke={'white'}
@@ -34,7 +54,7 @@ const LinearVenn = ({ theme, aOnly, aAndB, bOnly, max }) => {
           y={0}
           width={aAndBWidth}
           height={HEIGHT}
-          fill={halfwayColour}
+          fill="url(#diagonalHatch)"
           stroke={'white'}
         />
         <rect
@@ -46,19 +66,99 @@ const LinearVenn = ({ theme, aOnly, aAndB, bOnly, max }) => {
           stroke={'white'}
         />
       </g>
-
-      <g>
-        <rect
-          x={0}
-          y={0}
-          width={WIDTH}
-          height={HEIGHT}
-          fill={'none'}
-          stroke={theme.palette.grey[700]}
-        />
-      </g>
     </svg>
   );
 };
+
+const LEGEND_SQUARE_SIZE = 15;
+const LEGEND_PADDING = 3;
+const Legend = ({ theme, a, b, aAndB }) => (
+  <svg width={WIDTH} height={LEGEND_SQUARE_SIZE * 3 + LEGEND_PADDING * 2}>
+    <defs>
+      <pattern
+        id="diagonalHatchLegend"
+        width="4"
+        height="4"
+        patternTransform="rotate(45 0 0)"
+        patternUnits="userSpaceOnUse"
+      >
+        <line
+          x1="1"
+          y1="0"
+          x2="1"
+          y2="4"
+          strokeWidth="2"
+          stroke={theme.palette.primary.main}
+        />
+        <line
+          x1="3"
+          y1="0"
+          x2="3"
+          y2="4"
+          strokeWidth="2"
+          stroke={theme.palette.secondary.main}
+        />
+      </pattern>
+    </defs>
+    <g>
+      <rect
+        x={0}
+        y={0}
+        width={LEGEND_SQUARE_SIZE}
+        height={LEGEND_SQUARE_SIZE}
+        fill={theme.palette.primary.main}
+        stroke={'white'}
+      />
+      <text
+        x={LEGEND_SQUARE_SIZE + LEGEND_PADDING}
+        y={LEGEND_SQUARE_SIZE / 2}
+        fill={theme.palette.text.primary}
+        dominantBaseline="middle"
+      >
+        {a}
+      </text>
+    </g>
+    <g transform={`translate(0,${LEGEND_SQUARE_SIZE + LEGEND_PADDING})`}>
+      <rect
+        x={0}
+        y={0}
+        width={LEGEND_SQUARE_SIZE}
+        height={LEGEND_SQUARE_SIZE}
+        fill="url(#diagonalHatchLegend)"
+        stroke={'white'}
+      />
+      <text
+        x={LEGEND_SQUARE_SIZE + LEGEND_PADDING}
+        y={LEGEND_SQUARE_SIZE / 2}
+        fill={theme.palette.text.primary}
+        dominantBaseline="middle"
+      >
+        {aAndB}
+      </text>
+    </g>
+    <g
+      transform={`translate(0,${LEGEND_SQUARE_SIZE * 2 + LEGEND_PADDING * 2})`}
+    >
+      <rect
+        x={0}
+        y={0}
+        width={LEGEND_SQUARE_SIZE}
+        height={LEGEND_SQUARE_SIZE}
+        fill={theme.palette.secondary.main}
+        stroke={'white'}
+      />
+      <text
+        x={LEGEND_SQUARE_SIZE + LEGEND_PADDING}
+        y={LEGEND_SQUARE_SIZE / 2}
+        fill={theme.palette.text.primary}
+        dominantBaseline="middle"
+      >
+        {b}
+      </text>
+    </g>
+  </svg>
+);
+
+export const LinearVennLegend = withTheme()(Legend);
 
 export default withTheme()(LinearVenn);

--- a/src/public/common/LinearVenn.js
+++ b/src/public/common/LinearVenn.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import withTheme from '@material-ui/core/styles/withTheme';
+import * as d3 from 'd3';
+
+const WIDTH = 400;
+const HEIGHT = 18;
+
+const LinearVenn = ({ theme, aOnly, aAndB, bOnly, max }) => {
+  const aOnlyStart = 0;
+  const aOnlyWidth = (WIDTH * aOnly) / max;
+  const aAndBStart = aOnlyStart + aOnlyWidth;
+  const aAndBWidth = (WIDTH * aAndB) / max;
+  const bOnlyStart = aAndBStart + aAndBWidth;
+  const bOnlyWidth = (WIDTH * bOnly) / max;
+
+  const halfwayColour = d3.interpolateRgb(
+    d3.rgb(theme.palette.primary.main),
+    d3.rgb(theme.palette.secondary.main)
+  )(0.5);
+
+  return (
+    <svg width={WIDTH} height={HEIGHT}>
+      <g>
+        <rect
+          x={aOnlyStart}
+          y={0}
+          width={aOnlyWidth + aAndBWidth}
+          height={HEIGHT}
+          fill={theme.palette.primary.main}
+          stroke={'white'}
+        />
+        <rect
+          x={aAndBStart}
+          y={0}
+          width={aAndBWidth}
+          height={HEIGHT}
+          fill={halfwayColour}
+          stroke={'white'}
+        />
+        <rect
+          x={bOnlyStart}
+          y={0}
+          width={bOnlyWidth}
+          height={HEIGHT}
+          fill={theme.palette.secondary.main}
+          stroke={'white'}
+        />
+      </g>
+
+      <g>
+        <rect
+          x={0}
+          y={0}
+          width={WIDTH}
+          height={HEIGHT}
+          fill={'none'}
+          stroke={theme.palette.grey[700]}
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default withTheme()(LinearVenn);

--- a/src/public/disease/sections/RelatedDiseases/Section.js
+++ b/src/public/disease/sections/RelatedDiseases/Section.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import * as d3 from 'd3';
 
-import { OtTableRF, Link } from 'ot-ui';
+import { OtTableRF, Link, significantFigures } from 'ot-ui';
 
-import LinearVenn from '../../../common/LinearVenn';
+import LinearVenn, { LinearVennLegend } from '../../../common/LinearVenn';
 
 const columns = (name, maxTargetCountAOrB) => [
   {
@@ -16,6 +16,11 @@ const columns = (name, maxTargetCountAOrB) => [
       }
       return 1;
     },
+  },
+  {
+    id: 'score',
+    label: 'Similarity score',
+    renderCell: d => significantFigures(d.score),
   },
   {
     id: 'targetCountANotB',
@@ -31,7 +36,13 @@ const columns = (name, maxTargetCountAOrB) => [
   },
   {
     id: 'chart',
-    label: 'Venn diagram',
+    label: (
+      <LinearVennLegend
+        a={`Targets associated with ${name} but not the related disease`}
+        b={`Targets associated with the related disease but not ${name}`}
+        aAndB="Shared target associations"
+      />
+    ),
     renderCell: d => (
       <LinearVenn
         aOnly={d.targetCountANotB}
@@ -58,6 +69,8 @@ const Section = ({ efoId, name, data }) => {
       error={false}
       columns={columns(name, maxTargetCountAOrB)}
       data={rowsMapped}
+      sortBy="score"
+      order="desc"
     />
   );
 };

--- a/src/public/disease/sections/RelatedDiseases/Section.js
+++ b/src/public/disease/sections/RelatedDiseases/Section.js
@@ -9,7 +9,7 @@ const columns = (name, maxTargetCountAOrB) => [
   {
     id: 'B.name',
     label: 'Related disease',
-    renderCell: d => <Link to={`../${d.B.id}`}>{d.B.name}</Link>,
+    renderCell: d => <Link to={`/disease/${d.B.id}`}>{d.B.name}</Link>,
     comparator: (a, b) => {
       if (a.B.name <= b.B.name) {
         return -1;

--- a/src/public/disease/sections/RelatedDiseases/Section.js
+++ b/src/public/disease/sections/RelatedDiseases/Section.js
@@ -1,33 +1,11 @@
 import React from 'react';
-import withStyles from '@material-ui/core/styles/withStyles';
+import * as d3 from 'd3';
 
 import { OtTableRF, Link } from 'ot-ui';
 
-import Intersection from '../../../common/Intersection';
+import LinearVenn from '../../../common/LinearVenn';
 
-const styles = () => ({
-  container: {
-    width: '204px',
-    margin: '8px 0',
-  },
-});
-
-let SharedTargets = ({ d, classes }) => {
-  return (
-    <div className={classes.container}>
-      <Intersection
-        id={d.B.name}
-        a={d.targetCountANotB}
-        ab={d.targetCountAAndB}
-        b={d.targetCountBNotA}
-      />
-    </div>
-  );
-};
-
-SharedTargets = withStyles(styles)(SharedTargets);
-
-const columns = name => [
+const columns = (name, maxTargetCountAOrB) => [
   {
     id: 'B.name',
     label: 'Related disease',
@@ -40,22 +18,34 @@ const columns = name => [
     },
   },
   {
-    id: 'targetCountAAndB',
-    label: 'Number of shared target associations',
-    renderCell: d => <SharedTargets d={d} />,
+    id: 'targetCountANotB',
+    label: `Targets associated with ${name} but not the related disease`,
   },
   {
-    id: 'targetCountANotB',
-    label: `Targets associated with the related disease but not ${name}`,
+    id: 'targetCountAAndB',
+    label: 'Shared target associations',
   },
   {
     id: 'targetCountBNotA',
-    label: `Targets associated with ${name} but not the related disease`,
+    label: `Targets associated with the related disease but not ${name}`,
+  },
+  {
+    id: 'chart',
+    label: 'Venn diagram',
+    renderCell: d => (
+      <LinearVenn
+        aOnly={d.targetCountANotB}
+        bOnly={d.targetCountBNotA}
+        aAndB={d.targetCountAAndB}
+        max={maxTargetCountAOrB}
+      />
+    ),
   },
 ];
 
 const Section = ({ efoId, name, data }) => {
   const { rows } = data;
+  const maxTargetCountAOrB = d3.max(rows, d => d.targetCountAOrB);
   const rowsMapped = rows.map(d => ({
     ...d,
     targetCountANotB: d.targetCountA - d.targetCountAAndB,
@@ -66,7 +56,7 @@ const Section = ({ efoId, name, data }) => {
     <OtTableRF
       loading={false}
       error={false}
-      columns={columns(name)}
+      columns={columns(name, maxTargetCountAOrB)}
       data={rowsMapped}
     />
   );

--- a/src/public/disease/sections/RelatedDiseases/sectionQuery.gql
+++ b/src/public/disease/sections/RelatedDiseases/sectionQuery.gql
@@ -16,6 +16,7 @@ query RelatedDiseasesQuery($efoId: String!) {
           targetCountB
           targetCountAAndB
           targetCountAOrB
+          score
         }
       }
     }

--- a/src/public/target/sections/RelatedTargets/Section.js
+++ b/src/public/target/sections/RelatedTargets/Section.js
@@ -9,7 +9,7 @@ const columns = (symbol, maxDiseaseCountAOrB) => [
   {
     id: 'B.symbol',
     label: 'Related target',
-    renderCell: d => <Link to={`../${d.B.id}`}>{d.B.symbol}</Link>,
+    renderCell: d => <Link to={`/target/${d.B.id}`}>{d.B.symbol}</Link>,
     comparator: (a, b) => {
       if (a.B.symbol <= b.B.symbol) {
         return -1;

--- a/src/public/target/sections/RelatedTargets/Section.js
+++ b/src/public/target/sections/RelatedTargets/Section.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import * as d3 from 'd3';
 
-import { OtTableRF, Link } from 'ot-ui';
+import { OtTableRF, Link, significantFigures } from 'ot-ui';
 
-import LinearVenn from '../../../common/LinearVenn';
+import LinearVenn, { LinearVennLegend } from '../../../common/LinearVenn';
 
 const columns = (symbol, maxDiseaseCountAOrB) => [
   {
@@ -16,6 +16,11 @@ const columns = (symbol, maxDiseaseCountAOrB) => [
       }
       return 1;
     },
+  },
+  {
+    id: 'score',
+    label: 'Similarity score',
+    renderCell: d => significantFigures(d.score),
   },
   {
     id: 'diseaseCountANotB',
@@ -31,7 +36,13 @@ const columns = (symbol, maxDiseaseCountAOrB) => [
   },
   {
     id: 'chart',
-    label: 'Venn diagram',
+    label: (
+      <LinearVennLegend
+        a={`Diseases associated with ${symbol} but not the related target`}
+        b={`Diseases associated with the related target but not ${symbol}`}
+        aAndB="Shared disease associations"
+      />
+    ),
     renderCell: d => (
       <LinearVenn
         aOnly={d.diseaseCountANotB}
@@ -58,6 +69,8 @@ const Section = ({ ensgId, symbol, data }) => {
       error={false}
       columns={columns(symbol, maxDiseaseCountAOrB)}
       data={rowsMapped}
+      sortBy="score"
+      order="desc"
     />
   );
 };

--- a/src/public/target/sections/RelatedTargets/sectionQuery.gql
+++ b/src/public/target/sections/RelatedTargets/sectionQuery.gql
@@ -16,6 +16,7 @@ query RelatedTargetsQuery($ensgId: String!) {
           diseaseCountB
           diseaseCountAAndB
           diseaseCountAOrB
+          score
         }
       }
     }


### PR DESCRIPTION
This PR adds a linear Venn diagram to the related targets and related diseases sections. The motivation is to save space (vs. the non-proportional, circular Venn) and make the numbers comparable across rows. It also adds the similarity score, so that the original ordering can be returned to (after sorting by a different column).