### PR TITLE
Add linked targets and linked diseases to drug page

### DIFF
--- a/src/public/configuration.js
+++ b/src/public/configuration.js
@@ -29,6 +29,7 @@ export const drugSectionsDefaultOrder = [
   'mechanismsOfAction',
   'adverseEvents',
   'bibliography',
+  'linkedTargets',
 ];
 
 export const evidenceSectionsDefaultOrder = [

--- a/src/public/configuration.js
+++ b/src/public/configuration.js
@@ -30,6 +30,7 @@ export const drugSectionsDefaultOrder = [
   'adverseEvents',
   'bibliography',
   'linkedTargets',
+  'linkedDiseases',
 ];
 
 export const evidenceSectionsDefaultOrder = [

--- a/src/public/drug/sectionIndex.js
+++ b/src/public/drug/sectionIndex.js
@@ -3,10 +3,12 @@
 
 import * as adverseEventsRaw from './sections/AdverseEvents';
 import * as bibliographyRaw from './sections/Bibliography';
+import * as linkedDiseasesRaw from './sections/LinkedDiseases';
 import * as linkedTargetsRaw from './sections/LinkedTargets';
 import * as mechanismsOfActionRaw from './sections/MechanismsOfAction';
 
 export const adverseEvents = adverseEventsRaw;
 export const bibliography = bibliographyRaw;
+export const linkedDiseases = linkedDiseasesRaw;
 export const linkedTargets = linkedTargetsRaw;
 export const mechanismsOfAction = mechanismsOfActionRaw;

--- a/src/public/drug/sectionIndex.js
+++ b/src/public/drug/sectionIndex.js
@@ -3,8 +3,10 @@
 
 import * as adverseEventsRaw from './sections/AdverseEvents';
 import * as bibliographyRaw from './sections/Bibliography';
+import * as linkedTargetsRaw from './sections/LinkedTargets';
 import * as mechanismsOfActionRaw from './sections/MechanismsOfAction';
 
 export const adverseEvents = adverseEventsRaw;
 export const bibliography = bibliographyRaw;
+export const linkedTargets = linkedTargetsRaw;
 export const mechanismsOfAction = mechanismsOfActionRaw;

--- a/src/public/drug/sections/LinkedDiseases/Description.js
+++ b/src/public/drug/sections/LinkedDiseases/Description.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Description = ({ name }) => (
+  <React.Fragment>
+    Diseases associated with <strong>{name}</strong>.
+  </React.Fragment>
+);
+
+export default Description;

--- a/src/public/drug/sections/LinkedDiseases/Section.js
+++ b/src/public/drug/sections/LinkedDiseases/Section.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Link, OtTableRF } from 'ot-ui';
+
+const columns = [
+  {
+    id: 'name',
+    label: 'Name',
+    renderCell: d => <Link to={`/disease/${d.id}`}>{d.name}</Link>,
+  },
+  {
+    id: 'id',
+    label: 'EFO ID',
+    renderCell: d => (
+      <Link external to={`http://www.ebi.ac.uk/efo/${d.id}`}>
+        {d.id}
+      </Link>
+    ),
+  },
+];
+
+const Section = ({ data }) => (
+  <OtTableRF loading={false} error={false} columns={columns} data={data.rows} />
+);
+
+export default Section;

--- a/src/public/drug/sections/LinkedDiseases/Section.js
+++ b/src/public/drug/sections/LinkedDiseases/Section.js
@@ -9,13 +9,15 @@ const columns = [
     renderCell: d => <Link to={`/disease/${d.id}`}>{d.name}</Link>,
   },
   {
-    id: 'id',
-    label: 'EFO ID',
-    renderCell: d => (
-      <Link external to={`http://www.ebi.ac.uk/efo/${d.id}`}>
-        {d.id}
-      </Link>
-    ),
+    id: 'therapeuticAreas',
+    label: 'Therapeutic Areas',
+    renderCell: d =>
+      d.therapeuticAreas.map((t, i) => (
+        <React.Fragment key={i}>
+          {i > 0 ? ', ' : null}
+          <Link to={`/disease/${t.id}`}>{t.name}</Link>
+        </React.Fragment>
+      )),
   },
 ];
 

--- a/src/public/drug/sections/LinkedDiseases/Summary.js
+++ b/src/public/drug/sections/LinkedDiseases/Summary.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Summary = ({ linkedDiseaseCount }) => (
+  <React.Fragment>
+    {linkedDiseaseCount} disease{linkedDiseaseCount !== 1 ? 's' : ''}
+  </React.Fragment>
+);
+
+export default Summary;

--- a/src/public/drug/sections/LinkedDiseases/index.js
+++ b/src/public/drug/sections/LinkedDiseases/index.js
@@ -1,9 +1,10 @@
 import { loader } from 'graphql.macro';
 
-export const id = 'linkedTargets';
-export const name = 'Targets';
+export const id = 'linkedDiseases';
+export const name = 'Diseases';
 
-export const hasSummaryData = ({ linkedTargetCount }) => linkedTargetCount > 0;
+export const hasSummaryData = ({ linkedDiseaseCount }) =>
+  linkedDiseaseCount > 0;
 
 export const summaryQuery = loader('./summaryQuery.gql');
 export const sectionQuery = loader('./sectionQuery.gql');

--- a/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
+++ b/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
@@ -6,6 +6,10 @@ query LinkedDiseasesSectionQuery($chemblId: String!) {
         rows {
           name
           id
+          therapeuticAreas {
+            id
+            name
+          }
         }
       }
     }

--- a/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
+++ b/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
@@ -1,0 +1,13 @@
+query LinkedDiseasesSectionQuery($chemblId: String!) {
+  drug(chemblId: $chemblId) {
+    id
+    details {
+      linkedDiseases {
+        rows {
+          name
+          id
+        }
+      }
+    }
+  }
+}

--- a/src/public/drug/sections/LinkedDiseases/summaryQuery.gql
+++ b/src/public/drug/sections/LinkedDiseases/summaryQuery.gql
@@ -1,0 +1,5 @@
+fragment drugLinkedDiseasesFragment on DrugSummaries {
+  linkedDiseases {
+    linkedDiseaseCount
+  }
+}

--- a/src/public/drug/sections/LinkedTargets/Description.js
+++ b/src/public/drug/sections/LinkedTargets/Description.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    Targets linked with <strong>{name}</strong>.
+    Targets associated with <strong>{name}</strong>.
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/LinkedTargets/Description.js
+++ b/src/public/drug/sections/LinkedTargets/Description.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Description = ({ name }) => (
+  <React.Fragment>
+    Targets linked with <strong>{name}</strong>.
+  </React.Fragment>
+);
+
+export default Description;

--- a/src/public/drug/sections/LinkedTargets/Section.js
+++ b/src/public/drug/sections/LinkedTargets/Section.js
@@ -8,20 +8,6 @@ const columns = [
     label: 'Symbol',
     renderCell: d => <Link to={`/target/${d.id}`}>{d.symbol}</Link>,
   },
-  {
-    id: 'id',
-    label: 'Ensembl ID',
-    renderCell: d => (
-      <Link
-        external
-        to={`https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${
-          d.id
-        }`}
-      >
-        {d.id}
-      </Link>
-    ),
-  },
 ];
 
 const Section = ({ data }) => (

--- a/src/public/drug/sections/LinkedTargets/Section.js
+++ b/src/public/drug/sections/LinkedTargets/Section.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Link, OtTableRF } from 'ot-ui';
+
+const columns = [
+  {
+    id: 'symbol',
+    label: 'Symbol',
+    renderCell: d => <Link to={`/target/${d.id}`}>{d.symbol}</Link>,
+  },
+  {
+    id: 'id',
+    label: 'Ensembl ID',
+    renderCell: d => (
+      <Link
+        external
+        to={`https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${
+          d.id
+        }`}
+      >
+        {d.id}
+      </Link>
+    ),
+  },
+];
+
+const Section = ({ data }) => (
+  <OtTableRF loading={false} error={false} columns={columns} data={data.rows} />
+);
+
+export default Section;

--- a/src/public/drug/sections/LinkedTargets/Summary.js
+++ b/src/public/drug/sections/LinkedTargets/Summary.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Summary = ({ linkedTargetCount }) => (
+  <React.Fragment>
+    {linkedTargetCount} target{linkedTargetCount !== 1 ? 's' : ''}
+  </React.Fragment>
+);
+
+export default Summary;

--- a/src/public/drug/sections/LinkedTargets/index.js
+++ b/src/public/drug/sections/LinkedTargets/index.js
@@ -1,0 +1,13 @@
+import { loader } from 'graphql.macro';
+
+export const id = 'linkedTargets';
+export const name = 'Linked Targets';
+
+export const hasSummaryData = ({ linkedTargetCount }) => linkedTargetCount > 0;
+
+export const summaryQuery = loader('./summaryQuery.gql');
+export const sectionQuery = loader('./sectionQuery.gql');
+
+export { default as DescriptionComponent } from './Description';
+export { default as SummaryComponent } from './Summary';
+export { default as SectionComponent } from './Section';

--- a/src/public/drug/sections/LinkedTargets/index.js
+++ b/src/public/drug/sections/LinkedTargets/index.js
@@ -1,7 +1,7 @@
 import { loader } from 'graphql.macro';
 
 export const id = 'linkedTargets';
-export const name = 'Linked Targets';
+export const name = 'Associated Targets';
 
 export const hasSummaryData = ({ linkedTargetCount }) => linkedTargetCount > 0;
 

--- a/src/public/drug/sections/LinkedTargets/sectionQuery.gql
+++ b/src/public/drug/sections/LinkedTargets/sectionQuery.gql
@@ -1,0 +1,13 @@
+query LinkedTargetsSectionQuery($chemblId: String!) {
+  drug(chemblId: $chemblId) {
+    id
+    details {
+      linkedTargets {
+        rows {
+          symbol
+          id
+        }
+      }
+    }
+  }
+}

--- a/src/public/drug/sections/LinkedTargets/summaryQuery.gql
+++ b/src/public/drug/sections/LinkedTargets/summaryQuery.gql
@@ -1,0 +1,5 @@
+fragment drugLinkedTargetsFragment on DrugSummaries {
+  linkedTargets {
+    linkedTargetCount
+  }
+}

--- a/src/public/drug/sections/MechanismsOfAction/Description.js
+++ b/src/public/drug/sections/MechanismsOfAction/Description.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    TODO: Write a description component for <strong>{name}</strong>.
+    Known mechanisms of action for <strong>{name}</strong>.
   </React.Fragment>
 );
 


### PR DESCRIPTION
This PR adds sections for:
* linked targets (https://github.com/opentargets/platform/issues/668)
* linked diseases (https://github.com/opentargets/platform/issues/669)