### PR TITLE
Dynamically load expression atlas and protvista

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,15 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+
+    <!-- d3 v3 (needed by tntvis, while v5 is used for newer components) -->
+    <script
+      type="text/javascript"
+      language="javascript"
+      src="https://d3js.org/d3.v3.min.js"
+    ></script>
+
+    <!-- reactome browser (no npm package, it seems) -->
     <script
       type="text/javascript"
       language="javascript"

--- a/src/public/target/sections/Expression/custom/AtlasRenderer.js
+++ b/src/public/target/sections/Expression/custom/AtlasRenderer.js
@@ -15,11 +15,9 @@ class ExpressionAtlasRenderer extends React.Component {
     const { ensgId } = this.props;
     const { ExpressionAtlasHeatmap } = this.state;
     return ExpressionAtlasHeatmap ? (
-      <div>
-        <ExpressionAtlasHeatmap
-          query={{ species: 'homo sapiens', gene: ensgId }}
-        />
-      </div>
+      <ExpressionAtlasHeatmap
+        query={{ species: 'homo sapiens', gene: ensgId }}
+      />
     ) : null;
   }
 }

--- a/src/public/target/sections/Expression/custom/AtlasRenderer.js
+++ b/src/public/target/sections/Expression/custom/AtlasRenderer.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+class ExpressionAtlasRenderer extends React.Component {
+  state = {};
+  componentDidMount() {
+    import('expression-atlas-heatmap-highcharts').then(
+      ({ default: ExpressionAtlasHeatmap }) => {
+        this.setState({
+          ExpressionAtlasHeatmap,
+        });
+      }
+    );
+  }
+  render() {
+    const { ensgId } = this.props;
+    const { ExpressionAtlasHeatmap } = this.state;
+    return ExpressionAtlasHeatmap ? (
+      <div>
+        <ExpressionAtlasHeatmap
+          query={{ species: 'homo sapiens', gene: ensgId }}
+        />
+      </div>
+    ) : null;
+  }
+}
+
+export default ExpressionAtlasRenderer;

--- a/src/public/target/sections/Expression/custom/AtlasTab.js
+++ b/src/public/target/sections/Expression/custom/AtlasTab.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import Typography from '@material-ui/core/Typography';
-import ExpressionAtlasHeatmap from 'expression-atlas-heatmap-highcharts';
+import ExpressionAtlasRenderer from './AtlasRenderer';
 import { Link } from 'ot-ui';
 
 const AtlasTab = ({ ensgId }) => {
@@ -15,9 +15,7 @@ const AtlasTab = ({ ensgId }) => {
           Expression Atlas
         </Link>
       </Typography>
-      <ExpressionAtlasHeatmap
-        query={{ species: 'homo sapiens', gene: ensgId }}
-      />
+      <ExpressionAtlasRenderer ensgId={ensgId} />
     </Fragment>
   );
 };

--- a/src/public/target/sections/ProteinInformation/custom/ProtVistaRenderer.js
+++ b/src/public/target/sections/ProteinInformation/custom/ProtVistaRenderer.js
@@ -1,15 +1,31 @@
 import React from 'react';
-import ProtVista from 'ProtVista';
+import * as d3 from 'd3';
+
 import 'ProtVista/build/css/main.css';
 
 class ProtVistaRenderer extends React.Component {
+  state = {};
   componentDidMount() {
-    const { uniprotId } = this.props;
-    this.protVista = new ProtVista({
-      el: '#protvista',
-      uniprotacc: uniprotId,
-      exclusions: ['seqInfo'],
+    import('ProtVista').then(({ default: ProtVista }) => {
+      this.setState({ ProtVista });
     });
+  }
+  componentDidUpdate() {
+    const { ProtVista } = this.state;
+    if (ProtVista) {
+      // remove any previous content
+      d3.select('#protvista')
+        .selectAll('*')
+        .remove();
+
+      // restart the plugin
+      const { uniprotId } = this.props;
+      this.protVista = new ProtVista({
+        el: '#protvista',
+        uniprotacc: uniprotId,
+        exclusions: ['seqInfo'],
+      });
+    }
   }
   render() {
     return <div id="protvista" />;


### PR DESCRIPTION
Approximate sizes (before `gzip` applied) of code-splitting:

| Part | Size |
| -- | -- |
| main (third party code) | 2MB |
| protvista | 440KB |
| gxa | 1.21MB |
| litemol | 1.36MB |
| main (our code) | 272 KB |