### PR TITLE
Lf drug issue665

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@ code {
   fill: black;
 }
 .dc-chart .pie-slice path {
-  stroke: #afafaf;
+  stroke: #fff;
 }
 
 .dcChartOverflow svg {

--- a/src/public/common/sections/KnownDrugs/custom/FilterTable.js
+++ b/src/public/common/sections/KnownDrugs/custom/FilterTable.js
@@ -529,13 +529,19 @@ class KnownDrugsDetail extends React.Component {
               title="Clinical trials by phase"
             />
           </Grid>
-          <Grid item className={classes.dcChartSection}>
+          <Grid
+            item
+            className={classNames(classes.dcChartSection, 'dcChartOverflow')}
+          >
             <DCContainer
               id="dc-drug-by-type-chart"
               title="Unique drugs by type"
             />
           </Grid>
-          <Grid item className={classes.dcChartSection}>
+          <Grid
+            item
+            className={classNames(classes.dcChartSection, 'dcChartOverflow')}
+          >
             <DCContainer
               id="dc-drug-by-activity-chart"
               title="Unique drugs by activity"

--- a/src/public/common/sections/KnownDrugs/custom/FilterTable.js
+++ b/src/public/common/sections/KnownDrugs/custom/FilterTable.js
@@ -195,7 +195,7 @@ const styles = theme => ({
 // Ideally this kinda thing will be replaced by a d3 scale of some sort?
 const getPieColors = items => {
   return items.reduce((acc, item, i) => {
-    acc[item] = darken(0.1 * i, chartColour);
+    acc[item] = darken(0.05 * i, chartColour);
     return acc;
   }, {});
 };

--- a/src/public/common/sections/KnownDrugs/custom/FilterTable.js
+++ b/src/public/common/sections/KnownDrugs/custom/FilterTable.js
@@ -4,7 +4,7 @@ import withStyles from '@material-ui/core/styles/withStyles';
 import crossfilter from 'crossfilter2';
 import dc from 'dc';
 import * as d3 from 'd3';
-import { lighten } from 'polished';
+import { lighten, darken } from 'polished';
 
 import DCContainer from '../../../../common/DCContainer';
 import { Link, OtTableRF, DataDownloader } from 'ot-ui';
@@ -195,7 +195,7 @@ const styles = theme => ({
 // Ideally this kinda thing will be replaced by a d3 scale of some sort?
 const getPieColors = items => {
   return items.reduce((acc, item, i) => {
-    acc[item] = chartColour;
+    acc[item] = darken(0.1 * i, chartColour);
     return acc;
   }, {});
 };
@@ -389,6 +389,7 @@ class KnownDrugsDetail extends React.Component {
     this.activityColors = getPieColors(
       _.uniq(this.props.rows.map(row => row.drug.activity))
     );
+    console.log('colors: ', this.typeColors, this.activityColors);
     this.setupGroups();
     this.setupCharts();
   }

--- a/src/public/target/sections/CancerBiomarkers/custom/FilterTable.js
+++ b/src/public/target/sections/CancerBiomarkers/custom/FilterTable.js
@@ -4,7 +4,7 @@ import crossfilter from 'crossfilter2';
 import _ from 'lodash';
 import * as d3 from 'd3';
 import dc from 'dc';
-import { lighten } from 'polished';
+import { lighten, darken } from 'polished';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 import classNames from 'classnames';
@@ -220,7 +220,7 @@ const getDownloadRows = rows => {
 
 const getPieColors = items => {
   return items.reduce((acc, item, i) => {
-    acc[item.label] = chartColour;
+    acc[item.label] = darken(0.05 * i, chartColour);
     return acc;
   }, {});
 };


### PR DESCRIPTION
This PR addresses points in issue opentargets/platform#665 about known drugs charts:
 - set container overflow to visible to show otherwise truncated labels
 - set piecharts segments stroke to white (so segments appear separated by space)
 - set piecharts segments to have different colours (shades of blue, starting from current light blue)
