### PR TITLE
Add classic target associations page

### DIFF
--- a/src/public/common/FacetCheckbox.js
+++ b/src/public/common/FacetCheckbox.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
 import Checkbox from '@material-ui/core/Checkbox';
 
 const styles = theme => ({
@@ -17,19 +18,45 @@ const styles = theme => ({
       fontSize: '16px',
     },
   },
+  childrenContainer: {
+    marginLeft: '16px',
+  },
 });
 
-const FacetCheckbox = ({ classes, label, value, checked, onChange }) => (
-  <FormControlLabel
-    className={classes.label}
-    control={
-      <Checkbox
-        className={classes.checkbox}
-        {...{ value, checked, onChange }}
+const FacetCheckbox = ({
+  classes,
+  children,
+  label,
+  value,
+  checked,
+  onChange,
+  nested = false,
+}) =>
+  nested ? (
+    <React.Fragment>
+      <FormControlLabel
+        className={classes.label}
+        control={
+          <Checkbox
+            className={classes.checkbox}
+            {...{ value, checked, onChange }}
+          />
+        }
+        label={label}
       />
-    }
-    label={label}
-  />
-);
+      <FormGroup className={classes.childrenContainer}>{children}</FormGroup>
+    </React.Fragment>
+  ) : (
+    <FormControlLabel
+      className={classes.label}
+      control={
+        <Checkbox
+          className={classes.checkbox}
+          {...{ value, checked, onChange }}
+        />
+      }
+      label={label}
+    />
+  );
 
 export default withStyles(styles)(FacetCheckbox);

--- a/src/public/common/FacetCheckbox.js
+++ b/src/public/common/FacetCheckbox.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import withStyles from '@material-ui/core/styles/withStyles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+
+const styles = theme => ({
+  label: {
+    margin: 0,
+    '& span:last-child': {
+      fontSize: '0.75rem',
+    },
+  },
+  checkbox: {
+    width: '18px',
+    height: '16px',
+    '& svg': {
+      fontSize: '16px',
+    },
+  },
+});
+
+const FacetCheckbox = ({ classes, label, value, checked, onChange }) => (
+  <FormControlLabel
+    className={classes.label}
+    control={
+      <Checkbox
+        className={classes.checkbox}
+        {...{ value, checked, onChange }}
+      />
+    }
+    label={label}
+  />
+);
+
+export default withStyles(styles)(FacetCheckbox);

--- a/src/public/common/FacetContainer.js
+++ b/src/public/common/FacetContainer.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Typography from '@material-ui/core/Typography';
+
+const styles = theme => ({
+  facetContainer: {
+    borderTop: `1px solid ${theme.palette.grey[500]}`,
+    marginTop: '4px',
+    marginBottom: '8px',
+  },
+  childrenContainer: {
+    marginTop: '4px',
+    marginBottom: '4px',
+  },
+});
+
+const FacetContainer = ({ classes, name, children }) => (
+  <div className={classes.facetContainer}>
+    <Typography>
+      <strong>{name}</strong>
+    </Typography>
+    <div className={classes.childrenContainer}>{children}</div>
+  </div>
+);
+
+export default withStyles(styles)(FacetContainer);

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -174,10 +174,27 @@ class ClassicAssociations extends React.Component {
               : [];
           return (
             <Grid style={{ marginTop: '8px' }} container spacing={16}>
+              <Grid item xs={12}>
+                <Typography variant="h6">
+                  <strong>{commaSeparate(totalCount)} diseases</strong>{' '}
+                  associated with <strong>{symbol}</strong>
+                </Typography>
+              </Grid>
               <Grid item xs={12} md={3}>
                 <Card elevation={0}>
                   <CardContent>
                     <Typography variant="h6">Filter by</Typography>
+                    <FacetContainer name="Disease Name">
+                      <TextField
+                        id="associations-search"
+                        label="Search"
+                        value={search}
+                        onChange={event =>
+                          this.handleSearchChange(event.target.value)
+                        }
+                        fullWidth
+                      />
+                    </FacetContainer>
                     {facetsData
                       ? facets.map(f => (
                           <FacetContainer key={f.id} name={f.name}>
@@ -195,18 +212,6 @@ class ClassicAssociations extends React.Component {
               <Grid item xs={12} md={9}>
                 <Card elevation={0}>
                   <CardContent>
-                    <Typography variant="h6">
-                      <strong>{commaSeparate(totalCount)} diseases</strong>{' '}
-                      associated with <strong>{symbol}</strong>
-                    </Typography>
-                    <TextField
-                      id="associations-search"
-                      label="Search"
-                      value={search}
-                      onChange={event =>
-                        this.handleSearchChange(event.target.value)
-                      }
-                    />
                     <ClassicAssociationsTable
                       rows={rows}
                       dataTypes={dataTypes}

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -30,7 +30,7 @@ const associationsQuery = gql`
           }
           score
           scoresByDataType {
-            id
+            dataTypeId
             score
           }
         }
@@ -73,7 +73,9 @@ class ClassicAssociations extends React.Component {
             ...rest,
           }));
           const dataTypes =
-            rows.length > 0 ? rows[0].scoresByDataType.map(d => d.id) : [];
+            rows.length > 0
+              ? rows[0].scoresByDataType.map(d => d.dataTypeId)
+              : [];
           return (
             <Grid style={{ marginTop: '8px' }} container spacing={16}>
               <Grid item xs={12} md={3}>

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -5,9 +5,9 @@ import { print } from 'graphql/language/printer';
 import { Query } from 'react-apollo';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
 
 import { commaSeparate } from 'ot-ui';
 
@@ -153,8 +153,8 @@ class ClassicAssociations extends React.Component {
             <Grid style={{ marginTop: '8px' }} container spacing={16}>
               <Grid item xs={12} md={3}>
                 <Card elevation={0}>
-                  <CardHeader title="Filter by" />
                   <CardContent>
+                    <Typography variant="h6">Filter by</Typography>
                     {facetsData
                       ? facets.map(f => (
                           <FacetContainer key={f.id} name={f.name}>
@@ -171,15 +171,11 @@ class ClassicAssociations extends React.Component {
               </Grid>
               <Grid item xs={12} md={9}>
                 <Card elevation={0}>
-                  <CardHeader
-                    title={
-                      <React.Fragment>
-                        <strong>{commaSeparate(totalCount)} diseases</strong>{' '}
-                        associated with <strong>{symbol}</strong>
-                      </React.Fragment>
-                    }
-                  />
                   <CardContent>
+                    <Typography variant="h6">
+                      <strong>{commaSeparate(totalCount)} diseases</strong>{' '}
+                      associated with <strong>{symbol}</strong>
+                    </Typography>
                     <TextField
                       id="associations-search"
                       label="Search"

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -13,6 +13,7 @@ import { commaSeparate } from 'ot-ui';
 
 import * as facetsObject from './facetIndex';
 import ClassicAssociationsTable from './ClassicAssociationsTable';
+import FacetContainer from '../common/FacetContainer';
 
 const facets = Object.values(facetsObject);
 
@@ -156,12 +157,13 @@ class ClassicAssociations extends React.Component {
                   <CardContent>
                     {facetsData
                       ? facets.map(f => (
-                          <f.FacetComponent
-                            key={f.id}
-                            state={facetsState[f.id]}
-                            data={facetsData[f.id]}
-                            onFacetChange={this.handleFacetChange(f.id)}
-                          />
+                          <FacetContainer key={f.id} name={f.name}>
+                            <f.FacetComponent
+                              state={facetsState[f.id]}
+                              data={facetsData[f.id]}
+                              onFacetChange={this.handleFacetChange(f.id)}
+                            />
+                          </FacetContainer>
                         ))
                       : null}
                   </CardContent>

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import _ from 'lodash';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
+import TextField from '@material-ui/core/TextField';
 
 import ClassicAssociationsTable from './ClassicAssociationsTable';
 
@@ -14,10 +16,16 @@ const associationsQuery = gql`
     $first: Int
     $after: String
     $facets: TargetDiseasesConnectionFacetsInput
+    $search: String
   ) {
     target(ensgId: $ensgId) {
       id
-      diseasesConnection(first: $first, after: $after, facets: $facets) {
+      diseasesConnection(
+        first: $first
+        after: $after
+        facets: $facets
+        search: $search
+      ) {
         totalCount
         pageInfo {
           nextCursor
@@ -45,6 +53,8 @@ class ClassicAssociations extends React.Component {
     after: null,
     page: 1,
     facets: null,
+    search: '',
+    searchDebouced: '',
   };
   handlePaginationChange = () => {
     // TODO
@@ -52,22 +62,36 @@ class ClassicAssociations extends React.Component {
   handleSortByChange = () => {
     // TODO
   };
-  handleSearchChange = () => {
-    // TODO
+  handleSearchChange = search => {
+    this.setState({ search });
+    this.handleSearchDeboucedChange(search);
   };
+  handleSearchDeboucedChange = _.debounce(searchDebouced => {
+    this.setState({ searchDebouced });
+  }, 500);
   handleFacetChange = () => {
     // TODO
   };
   render() {
     const { ensgId, symbol } = this.props;
+    const { search, searchDebouced } = this.state;
     return (
-      <Query query={associationsQuery} variables={{ ensgId }}>
+      <Query
+        query={associationsQuery}
+        variables={{ ensgId, search: searchDebouced ? searchDebouced : null }}
+      >
         {({ loading, error, data }) => {
-          if (loading || error) {
+          if (error) {
             return null;
           }
-          console.log(data);
-          const { totalCount, edges } = data.target.diseasesConnection;
+
+          let edges;
+          if (loading) {
+            edges = [];
+          } else {
+            edges = data.target.diseasesConnection.edges;
+          }
+
           const rows = edges.map(({ node, ...rest }) => ({
             disease: node,
             ...rest,
@@ -88,6 +112,15 @@ class ClassicAssociations extends React.Component {
                 <Card elevation={0}>
                   <CardHeader title="Filter by" subheader={'blah'} />
                   <CardContent>
+                    <TextField
+                      id="associations-search"
+                      label="Search"
+                      value={search}
+                      onChange={event =>
+                        this.handleSearchChange(event.target.value)
+                      }
+                      margin="normal"
+                    />
                     <ClassicAssociationsTable
                       rows={rows}
                       dataTypes={dataTypes}

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -1,7 +1,104 @@
 import React from 'react';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+import Grid from '@material-ui/core/Grid';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
 
-const ClassicAssociations = ({ ensgId, uniprotId, symbol, name }) => (
-  <div>boo!</div>
-);
+import ClassicAssociationsTable from './ClassicAssociationsTable';
+
+const associationsQuery = gql`
+  query TargetAssociationsQuery(
+    $ensgId: String!
+    $first: Int
+    $after: String
+    $facets: TargetDiseasesConnectionFacetsInput
+  ) {
+    target(ensgId: $ensgId) {
+      id
+      diseasesConnection(first: $first, after: $after, facets: $facets) {
+        totalCount
+        pageInfo {
+          nextCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            id
+            name
+          }
+          score
+          scoresByDataType {
+            id
+            score
+          }
+        }
+      }
+    }
+  }
+`;
+
+class ClassicAssociations extends React.Component {
+  state = {
+    first: 50,
+    after: null,
+    page: 1,
+    facets: null,
+  };
+  handlePaginationChange = () => {
+    // TODO
+  };
+  handleSortByChange = () => {
+    // TODO
+  };
+  handleSearchChange = () => {
+    // TODO
+  };
+  handleFacetChange = () => {
+    // TODO
+  };
+  render() {
+    const { ensgId, symbol } = this.props;
+    return (
+      <Query query={associationsQuery} variables={{ ensgId }}>
+        {({ loading, error, data }) => {
+          if (loading || error) {
+            return null;
+          }
+          console.log(data);
+          const { totalCount, edges } = data.target.diseasesConnection;
+          const rows = edges.map(({ node, ...rest }) => ({
+            disease: node,
+            ...rest,
+          }));
+          const dataTypes =
+            rows.length > 0 ? rows[0].scoresByDataType.map(d => d.id) : [];
+          return (
+            <Grid style={{ marginTop: '8px' }} container spacing={16}>
+              <Grid item xs={12} md={3}>
+                <Card elevation={0}>
+                  <CardHeader title="Filter by" subheader={'blah'} />
+                  <CardContent></CardContent>
+                </Card>
+              </Grid>
+              <Grid item xs={12} md={9}>
+                <Card elevation={0}>
+                  <CardHeader title="Filter by" subheader={'blah'} />
+                  <CardContent>
+                    <ClassicAssociationsTable
+                      rows={rows}
+                      dataTypes={dataTypes}
+                    />
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+          );
+        }}
+      </Query>
+    );
+  }
+}
 
 export default ClassicAssociations;

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -16,6 +16,7 @@ const associationsQuery = gql`
     $first: Int
     $after: String
     $facets: TargetDiseasesConnectionFacetsInput
+    $sortBy: TargetDiseasesConnectionSortByInput
     $search: String
   ) {
     target(ensgId: $ensgId) {
@@ -24,6 +25,7 @@ const associationsQuery = gql`
         first: $first
         after: $after
         facets: $facets
+        sortBy: $sortBy
         search: $search
       ) {
         totalCount
@@ -55,12 +57,13 @@ class ClassicAssociations extends React.Component {
     facets: null,
     search: '',
     searchDebouced: '',
+    sortBy: { field: 'SCORE_OVERALL', ascending: false },
   };
   handlePaginationChange = () => {
     // TODO
   };
-  handleSortByChange = () => {
-    // TODO
+  handleSortByChange = sortBy => {
+    this.setState({ sortBy });
   };
   handleSearchChange = search => {
     this.setState({ search });
@@ -74,11 +77,15 @@ class ClassicAssociations extends React.Component {
   };
   render() {
     const { ensgId, symbol } = this.props;
-    const { search, searchDebouced } = this.state;
+    const { search, searchDebouced, sortBy } = this.state;
     return (
       <Query
         query={associationsQuery}
-        variables={{ ensgId, search: searchDebouced ? searchDebouced : null }}
+        variables={{
+          ensgId,
+          sortBy,
+          search: searchDebouced ? searchDebouced : null,
+        }}
       >
         {({ loading, error, data }) => {
           if (error) {
@@ -124,6 +131,8 @@ class ClassicAssociations extends React.Component {
                     <ClassicAssociationsTable
                       rows={rows}
                       dataTypes={dataTypes}
+                      sortBy={sortBy}
+                      onSortByChange={this.handleSortByChange}
                     />
                   </CardContent>
                 </Card>

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -8,6 +8,8 @@ import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 import TextField from '@material-ui/core/TextField';
 
+import { commaSeparate } from 'ot-ui';
+
 import ClassicAssociationsTable from './ClassicAssociationsTable';
 
 const associationsQuery = gql`
@@ -93,10 +95,12 @@ class ClassicAssociations extends React.Component {
           }
 
           let edges;
+          let totalCount;
           if (loading) {
             edges = [];
           } else {
             edges = data.target.diseasesConnection.edges;
+            totalCount = data.target.diseasesConnection.totalCount;
           }
 
           const rows = edges.map(({ node, ...rest }) => ({
@@ -117,7 +121,14 @@ class ClassicAssociations extends React.Component {
               </Grid>
               <Grid item xs={12} md={9}>
                 <Card elevation={0}>
-                  <CardHeader title="Filter by" subheader={'blah'} />
+                  <CardHeader
+                    title={
+                      <React.Fragment>
+                        <strong>{commaSeparate(totalCount)} diseases</strong>{' '}
+                        associated with <strong>{symbol}</strong>
+                      </React.Fragment>
+                    }
+                  />
                   <CardContent>
                     <TextField
                       id="associations-search"
@@ -126,7 +137,6 @@ class ClassicAssociations extends React.Component {
                       onChange={event =>
                         this.handleSearchChange(event.target.value)
                       }
-                      margin="normal"
                     />
                     <ClassicAssociationsTable
                       rows={rows}

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ClassicAssociations = ({ ensgId, uniprotId, symbol, name }) => (
+  <div>boo!</div>
+);
+
+export default ClassicAssociations;

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -129,7 +129,10 @@ class ClassicAssociations extends React.Component {
           let edges;
           let totalCount;
           let facetsData;
-          if (loading) {
+          if (
+            loading &&
+            !(data && data.target && data.target.diseasesConnection)
+          ) {
             edges = [];
           } else {
             edges = data.target.diseasesConnection.edges;

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -16,6 +16,10 @@ const styles = theme => ({
   tableWrapper: {
     overflowX: 'auto',
   },
+  table: {
+    marginRight: '20px',
+    width: 'calc(100% - 40px)',
+  },
   cell: {
     padding: '1px',
     borderBottom: 'none',
@@ -83,7 +87,7 @@ const ClassicAssociationsTable = ({
   const activeForField = field => sortBy.field === field;
   return (
     <div className={classes.tableWrapper}>
-      <Table padding="none">
+      <Table className={classes.table} padding="none">
         <TableHead>
           <TableRow>
             <TableCell className={classes.cellDiseaseName}>Disease</TableCell>

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -18,11 +18,12 @@ const styles = theme => ({
   },
   cell: {
     padding: '1px',
+    borderBottom: 'none',
   },
   cellSwatch: {
     minWidth: '20px',
     width: '100%',
-    height: '20px',
+    height: '12px',
     padding: '1px',
   },
   cellEllipsis: {
@@ -54,8 +55,11 @@ const styles = theme => ({
     },
   },
   cellDiseaseName: {
+    fontSize: '0.75rem',
+    padding: '0 8px',
     minWidth: '200px',
     maxWidth: '400px',
+    borderBottom: 'none',
   },
 });
 const ClassicAssociationsTable = ({

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -6,6 +6,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
 
 const styles = theme => ({
   tableWrapper: {
@@ -33,6 +34,7 @@ const styles = theme => ({
     maxWidth: '20px',
     height: '200px',
     verticalAlign: 'bottom',
+    textAlign: 'center',
     '& div': {
       height: '1px',
       verticalAlign: 'top',
@@ -47,9 +49,14 @@ const styles = theme => ({
     },
   },
 });
-const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
-  console.log(rows);
-
+const ClassicAssociationsTable = ({
+  classes,
+  theme,
+  rows,
+  dataTypes,
+  sortBy,
+  onSortByChange,
+}) => {
   const colorScale = d3
     .scaleLinear()
     .domain([0, 1])
@@ -64,6 +71,25 @@ const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
               <div>
                 <span>Overall</span>
               </div>
+              <TableSortLabel
+                onClick={() =>
+                  onSortByChange({
+                    field: 'SCORE_OVERALL',
+                    ascending:
+                      sortBy.field === 'SCORE_OVERALL'
+                        ? !sortBy.ascending
+                        : false,
+                  })
+                }
+                direction={
+                  sortBy.field === 'SCORE_OVERALL'
+                    ? sortBy.ascending
+                      ? 'asc'
+                      : 'desc'
+                    : 'desc'
+                }
+                active={sortBy.field === 'SCORE_OVERALL'}
+              />
             </TableCell>
             {dataTypes.map(dataType => (
               <TableCell key={dataType} className={classes.cellHeaderVertical}>

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as d3 from 'd3';
+import _ from 'lodash';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
@@ -46,6 +47,7 @@ const styles = theme => ({
       marginLeft: '50%',
       transformOrigin: '0 0',
       transform: 'rotate(-60deg) translateY(-50%)',
+      whiteSpace: 'nowrap',
     },
   },
 });
@@ -89,7 +91,7 @@ const ClassicAssociationsTable = ({
             {dataTypes.map(dataType => (
               <TableCell key={dataType} className={classes.cellHeaderVertical}>
                 <div>
-                  <span>{dataType}</span>
+                  <span>{_.startCase(dataType.toLowerCase())}</span>
                 </div>
                 <TableSortLabel
                   onClick={() => onSortByChange(sortByUpdateForField(dataType))}

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -22,14 +22,13 @@ const styles = theme => ({
     width: 'calc(100% - 40px)',
   },
   cell: {
-    padding: '1px',
     borderBottom: 'none',
   },
   cellSwatch: {
     minWidth: '20px',
     width: '100%',
-    height: '12px',
-    padding: '1px',
+    height: '16px',
+    border: `1px solid ${theme.palette.grey[200]}`,
   },
   cellEllipsis: {
     overflow: 'hidden',
@@ -67,6 +66,10 @@ const styles = theme => ({
     maxWidth: '400px',
     borderBottom: 'none',
   },
+  cellHeaderDiseaseName: {
+    verticalAlign: 'bottom',
+    paddingBottom: '35px',
+  },
 });
 const ClassicAssociationsTable = ({
   classes,
@@ -97,7 +100,15 @@ const ClassicAssociationsTable = ({
       <Table className={classes.table} padding="none">
         <TableHead>
           <TableRow>
-            <TableCell className={classes.cellDiseaseName}>Disease</TableCell>
+            <TableCell
+              align="right"
+              className={classNames(
+                classes.cellDiseaseName,
+                classes.cellHeaderDiseaseName
+              )}
+            >
+              Disease
+            </TableCell>
             <TableCell className={classes.cellHeaderVertical}>
               <div>
                 <span>Overall</span>

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -41,7 +41,7 @@ const styles = theme => ({
   cellHeaderVertical: {
     minWidth: '20px',
     maxWidth: '20px',
-    height: '200px',
+    height: '160px',
     verticalAlign: 'bottom',
     textAlign: 'center',
     borderBottom: 'none',

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import * as d3 from 'd3';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableBody from '@material-ui/core/TableBody';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+
+const styles = theme => ({
+  tableWrapper: {
+    overflowX: 'auto',
+  },
+  tableCellHeader: {
+    height: '200px',
+    whiteSpace: 'nowrap',
+    padding: '0 !important',
+  },
+  tableCellHeaderVerticalLabel: {
+    transform: 'rotate(-90deg)',
+    width: '30px',
+  },
+  cell: {
+    padding: '1px',
+  },
+  cellSwatch: {
+    width: '100%',
+    height: '1rem',
+    padding: '1px',
+  },
+  cellEllipsis: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  row: {
+    height: 0,
+  },
+  cellHeaderVertical: {
+    maxWidth: '50px',
+    height: '200px',
+    verticalAlign: 'bottom',
+    '& div': {
+      height: '1px',
+      verticalAlign: 'top',
+      marginBottom: '20px',
+    },
+    '& div span': {
+      display: 'block',
+      maxWidth: '200px',
+      marginLeft: '50%',
+      transformOrigin: '0 0',
+      transform: 'rotate(-60deg) translateY(-50%)',
+    },
+  },
+});
+const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
+  const colorScale = d3
+    .scaleLinear()
+    .domain([0, 1])
+    .range(['#fff', theme.palette.primary.main]);
+  return (
+    <div className={classes.tableWrapper}>
+      <Table padding="none">
+        <TableHead>
+          <TableRow>
+            <TableCell>Disease</TableCell>
+            {dataTypes.map(dataType => (
+              <TableCell key={dataType} className={classes.cellHeaderVertical}>
+                <div>
+                  <span>{dataType}</span>
+                </div>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map(row => (
+            <TableRow
+              key={row.disease.id}
+              padding="dense"
+              className={classes.row}
+            >
+              <TableCell padding="dense" className={classes.cellEllipsis}>
+                {row.disease.name}
+              </TableCell>
+              {row.scoresByDataType.map(dataType => (
+                <TableCell key={dataType.id} className={classes.cell}>
+                  <div
+                    className={classes.cellSwatch}
+                    style={
+                      dataType.score
+                        ? { background: colorScale(dataType.score) }
+                        : null
+                    }
+                  />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default withStyles(styles, { withTheme: true })(
+  ClassicAssociationsTable
+);

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -9,6 +9,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
+import TablePagination from '@material-ui/core/TablePagination';
 
 // TODO: Harmonise with HeatmapTable for component reuse
 
@@ -74,6 +75,11 @@ const ClassicAssociationsTable = ({
   dataTypes,
   sortBy,
   onSortByChange,
+  page,
+  rowsPerPage,
+  totalCount,
+  pageInfo,
+  onPaginationChange,
 }) => {
   const colorScale = d3
     .scaleLinear()
@@ -159,6 +165,25 @@ const ClassicAssociationsTable = ({
           ))}
         </TableBody>
       </Table>
+
+      <TablePagination
+        component="div"
+        rowsPerPageOptions={[]}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        count={totalCount ? totalCount : 0}
+        backIconButtonProps={{
+          'aria-label': 'Previous Page',
+        }}
+        nextIconButtonProps={{
+          'aria-label': 'Next Page',
+        }}
+        onChangePage={(event, newPage) => {
+          const { nextCursor } = pageInfo;
+          const forward = newPage > page;
+          onPaginationChange(forward, nextCursor);
+        }}
+      />
     </div>
   );
 };

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -11,21 +11,13 @@ const styles = theme => ({
   tableWrapper: {
     overflowX: 'auto',
   },
-  tableCellHeader: {
-    height: '200px',
-    whiteSpace: 'nowrap',
-    padding: '0 !important',
-  },
-  tableCellHeaderVerticalLabel: {
-    transform: 'rotate(-90deg)',
-    width: '30px',
-  },
   cell: {
     padding: '1px',
   },
   cellSwatch: {
+    minWidth: '20px',
     width: '100%',
-    height: '1rem',
+    height: '20px',
     padding: '1px',
   },
   cellEllipsis: {
@@ -37,7 +29,8 @@ const styles = theme => ({
     height: 0,
   },
   cellHeaderVertical: {
-    maxWidth: '50px',
+    minWidth: '20px',
+    maxWidth: '20px',
     height: '200px',
     verticalAlign: 'bottom',
     '& div': {
@@ -55,6 +48,8 @@ const styles = theme => ({
   },
 });
 const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
+  console.log(rows);
+
   const colorScale = d3
     .scaleLinear()
     .domain([0, 1])
@@ -65,6 +60,11 @@ const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
         <TableHead>
           <TableRow>
             <TableCell>Disease</TableCell>
+            <TableCell className={classes.cellHeaderVertical}>
+              <div>
+                <span>Overall</span>
+              </div>
+            </TableCell>
             {dataTypes.map(dataType => (
               <TableCell key={dataType} className={classes.cellHeaderVertical}>
                 <div>
@@ -81,11 +81,23 @@ const ClassicAssociationsTable = ({ classes, theme, rows, dataTypes }) => {
               padding="dense"
               className={classes.row}
             >
-              <TableCell padding="dense" className={classes.cellEllipsis}>
+              <TableCell
+                align="right"
+                padding="dense"
+                className={classes.cellEllipsis}
+              >
                 {row.disease.name}
               </TableCell>
+              <TableCell className={classes.cell}>
+                <div
+                  className={classes.cellSwatch}
+                  style={
+                    row.score ? { background: colorScale(row.score) } : null
+                  }
+                />
+              </TableCell>
               {row.scoresByDataType.map(dataType => (
-                <TableCell key={dataType.id} className={classes.cell}>
+                <TableCell key={dataType.dataTypeId} className={classes.cell}>
                   <div
                     className={classes.cellSwatch}
                     style={

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as d3 from 'd3';
 import _ from 'lodash';
+import classNames from 'classnames';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
@@ -8,6 +9,8 @@ import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
+
+// TODO: Harmonise with HeatmapTable for component reuse
 
 const styles = theme => ({
   tableWrapper: {
@@ -50,6 +53,10 @@ const styles = theme => ({
       whiteSpace: 'nowrap',
     },
   },
+  cellDiseaseName: {
+    minWidth: '200px',
+    maxWidth: '400px',
+  },
 });
 const ClassicAssociationsTable = ({
   classes,
@@ -75,7 +82,7 @@ const ClassicAssociationsTable = ({
       <Table padding="none">
         <TableHead>
           <TableRow>
-            <TableCell>Disease</TableCell>
+            <TableCell className={classes.cellDiseaseName}>Disease</TableCell>
             <TableCell className={classes.cellHeaderVertical}>
               <div>
                 <span>Overall</span>
@@ -112,7 +119,10 @@ const ClassicAssociationsTable = ({
               <TableCell
                 align="right"
                 padding="dense"
-                className={classes.cellEllipsis}
+                className={classNames(
+                  classes.cellDiseaseName,
+                  classes.cellEllipsis
+                )}
               >
                 {row.disease.name}
               </TableCell>

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -44,6 +44,7 @@ const styles = theme => ({
     height: '200px',
     verticalAlign: 'bottom',
     textAlign: 'center',
+    borderBottom: 'none',
     '& div': {
       height: '1px',
       verticalAlign: 'top',

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -61,6 +61,13 @@ const ClassicAssociationsTable = ({
     .scaleLinear()
     .domain([0, 1])
     .range(['#fff', theme.palette.primary.main]);
+  const sortByUpdateForField = field => ({
+    field: field,
+    ascending: sortBy.field === field ? !sortBy.ascending : false,
+  });
+  const directionForField = field =>
+    sortBy.field === field ? (sortBy.ascending ? 'asc' : 'desc') : 'desc';
+  const activeForField = field => sortBy.field === field;
   return (
     <div className={classes.tableWrapper}>
       <Table padding="none">
@@ -73,22 +80,10 @@ const ClassicAssociationsTable = ({
               </div>
               <TableSortLabel
                 onClick={() =>
-                  onSortByChange({
-                    field: 'SCORE_OVERALL',
-                    ascending:
-                      sortBy.field === 'SCORE_OVERALL'
-                        ? !sortBy.ascending
-                        : false,
-                  })
+                  onSortByChange(sortByUpdateForField('SCORE_OVERALL'))
                 }
-                direction={
-                  sortBy.field === 'SCORE_OVERALL'
-                    ? sortBy.ascending
-                      ? 'asc'
-                      : 'desc'
-                    : 'desc'
-                }
-                active={sortBy.field === 'SCORE_OVERALL'}
+                direction={directionForField('SCORE_OVERALL')}
+                active={activeForField('SCORE_OVERALL')}
               />
             </TableCell>
             {dataTypes.map(dataType => (
@@ -96,6 +91,11 @@ const ClassicAssociationsTable = ({
                 <div>
                   <span>{dataType}</span>
                 </div>
+                <TableSortLabel
+                  onClick={() => onSortByChange(sortByUpdateForField(dataType))}
+                  direction={directionForField(dataType)}
+                  active={activeForField(dataType)}
+                />
               </TableCell>
             ))}
           </TableRow>

--- a/src/public/target/Page.js
+++ b/src/public/target/Page.js
@@ -7,6 +7,7 @@ import { Helmet } from 'react-helmet';
 import { Tabs, Tab } from 'ot-ui';
 
 import Header from './Header';
+import ClassicAssociations from './ClassicAssociations';
 import Associations from './Associations';
 import Profile from './Profile';
 
@@ -23,14 +24,27 @@ const targetQuery = gql`
   }
 `;
 
+const valueToUrlSuffixMap = {
+  classicAssociations: '/classic-associations',
+  associations: '/associations',
+  overview: '',
+};
+const urlSuffixToValueMap = Object.entries(valueToUrlSuffixMap).reduce(
+  (acc, [k, v]) => {
+    acc[v] = k;
+    return acc;
+  },
+  {}
+);
+
 class TargetPage extends Component {
   state = {};
 
   static getDerivedStateFromProps(props) {
-    const value = props.location.pathname.endsWith('/associations')
-      ? 'associations'
-      : 'overview';
-
+    const suffix = props.location.pathname.endsWith('associations')
+      ? `/${props.location.pathname.split('/').pop()}`
+      : '';
+    const value = urlSuffixToValueMap[suffix];
     return {
       value,
     };
@@ -39,9 +53,8 @@ class TargetPage extends Component {
   handleChange = (event, value) => {
     const { history, match } = this.props;
     this.setState({ value }, () => {
-      history.push(
-        `${match.url}${value === 'overview' ? '' : '/associations'}`
-      );
+      const suffix = valueToUrlSuffixMap[value];
+      history.push(`${match.url}${suffix}`);
     });
   };
 
@@ -77,10 +90,27 @@ class TargetPage extends Component {
                 variant="scrollable"
                 scrollButtons="auto"
               >
-                <Tab value="associations" label="Associations View" />
-                <Tab value="overview" label="Target Profile" />
+                <Tab
+                  value="classicAssociations"
+                  label="Associations (classic)"
+                />
+                <Tab value="associations" label="Associations (dynamic)" />
+                <Tab value="overview" label="Profile" />
               </Tabs>
               <Switch>
+                <Route
+                  path={`${match.path}/classic-associations`}
+                  render={() => (
+                    <ClassicAssociations
+                      {...{
+                        ensgId,
+                        uniprotId,
+                        symbol,
+                        name,
+                      }}
+                    />
+                  )}
+                />
                 <Route
                   path={`${match.path}/associations`}
                   render={() => (

--- a/src/public/target/facetIndex.js
+++ b/src/public/target/facetIndex.js
@@ -1,0 +1,8 @@
+// TODO: see if this can be done dynamically
+//       or try @babel/plugin-proposal-export-namespace-from (may need eject)
+
+import * as dataTypeAndSourceRaw from './facets/DataTypeAndSource';
+import * as therapeuticAreaRaw from './facets/TherapeuticArea';
+
+export const dataTypeAndSource = dataTypeAndSourceRaw;
+export const therapeuticArea = therapeuticAreaRaw;

--- a/src/public/target/facets/DataTypeAndSource.js
+++ b/src/public/target/facets/DataTypeAndSource.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import FormLabel from '@material-ui/core/FormLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
+
+import FacetCheckbox from '../../common/FacetCheckbox';
 
 export const id = 'dataTypeAndSource';
 export const name = 'Data Type and Source';
@@ -21,4 +26,52 @@ export const facetQuery = gql`
   }
 `;
 
-export const FacetComponent = () => <div>data type and source</div>;
+export const stateDefault = {
+  dataTypeIds: [],
+  dataSourceIds: [],
+};
+export const stateToInput = state => {
+  const input = {};
+  if (state.dataTypeIds.length > 0) {
+    input.dataTypeIds = state.dataTypeIds;
+  }
+  if (state.dataSourceIds.length > 0) {
+    input.dataSourceIds = state.dataSourceIds;
+  }
+  return input;
+};
+
+export const FacetComponent = ({ state, data, onFacetChange }) => (
+  <div>
+    <FormControl component="fieldset">
+      <FormLabel component="legend">{name}</FormLabel>
+      <FormGroup>
+        {data.items.map(item => (
+          <FacetCheckbox
+            key={item.id}
+            checked={state.dataTypeIds.indexOf(item.id) >= 0}
+            onChange={() => {
+              let newDataTypeIds;
+              if (state.dataTypeIds.indexOf(item.id) >= 0) {
+                // switch off
+                newDataTypeIds = state.dataTypeIds.filter(d => d !== item.id);
+              } else {
+                // switch on
+                newDataTypeIds = [item.id, ...state.dataTypeIds];
+              }
+              const newState = {
+                ...state,
+                dataTypeIds: newDataTypeIds,
+              };
+
+              // update
+              onFacetChange(newState);
+            }}
+            value={item.id}
+            label={`${item.name} (${item.count})`}
+          />
+        ))}
+      </FormGroup>
+    </FormControl>
+  </div>
+);

--- a/src/public/target/facets/DataTypeAndSource.js
+++ b/src/public/target/facets/DataTypeAndSource.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
 

--- a/src/public/target/facets/DataTypeAndSource.js
+++ b/src/public/target/facets/DataTypeAndSource.js
@@ -44,11 +44,11 @@ export const stateToInput = state => {
 export const FacetComponent = ({ state, data, onFacetChange }) => (
   <div>
     <FormControl component="fieldset">
-      <FormLabel component="legend">{name}</FormLabel>
       <FormGroup>
         {data.items.map(item => (
           <FacetCheckbox
             key={item.id}
+            nested
             checked={state.dataTypeIds.indexOf(item.id) >= 0}
             onChange={() => {
               let newDataTypeIds;
@@ -69,7 +69,36 @@ export const FacetComponent = ({ state, data, onFacetChange }) => (
             }}
             value={item.id}
             label={`${item.name} (${item.count})`}
-          />
+          >
+            {item.children.map(childItem => (
+              <FacetCheckbox
+                key={childItem.id}
+                nested
+                checked={state.dataSourceIds.indexOf(childItem.id) >= 0}
+                onChange={() => {
+                  let newDataSourceIds;
+                  if (state.dataSourceIds.indexOf(childItem.id) >= 0) {
+                    // switch off
+                    newDataSourceIds = state.dataSourceIds.filter(
+                      d => d !== childItem.id
+                    );
+                  } else {
+                    // switch on
+                    newDataSourceIds = [childItem.id, ...state.dataSourceIds];
+                  }
+                  const newState = {
+                    ...state,
+                    dataSourceIds: newDataSourceIds,
+                  };
+
+                  // update
+                  onFacetChange(newState);
+                }}
+                value={childItem.id}
+                label={`${childItem.name} (${childItem.count})`}
+              />
+            ))}
+          </FacetCheckbox>
         ))}
       </FormGroup>
     </FormControl>

--- a/src/public/target/facets/DataTypeAndSource.js
+++ b/src/public/target/facets/DataTypeAndSource.js
@@ -42,65 +42,63 @@ export const stateToInput = state => {
 };
 
 export const FacetComponent = ({ state, data, onFacetChange }) => (
-  <div>
-    <FormControl component="fieldset">
-      <FormGroup>
-        {data.items.map(item => (
-          <FacetCheckbox
-            key={item.id}
-            nested
-            checked={state.dataTypeIds.indexOf(item.id) >= 0}
-            onChange={() => {
-              let newDataTypeIds;
-              if (state.dataTypeIds.indexOf(item.id) >= 0) {
-                // switch off
-                newDataTypeIds = state.dataTypeIds.filter(d => d !== item.id);
-              } else {
-                // switch on
-                newDataTypeIds = [item.id, ...state.dataTypeIds];
-              }
-              const newState = {
-                ...state,
-                dataTypeIds: newDataTypeIds,
-              };
+  <FormControl component="fieldset">
+    <FormGroup>
+      {data.items.map(item => (
+        <FacetCheckbox
+          key={item.id}
+          nested
+          checked={state.dataTypeIds.indexOf(item.id) >= 0}
+          onChange={() => {
+            let newDataTypeIds;
+            if (state.dataTypeIds.indexOf(item.id) >= 0) {
+              // switch off
+              newDataTypeIds = state.dataTypeIds.filter(d => d !== item.id);
+            } else {
+              // switch on
+              newDataTypeIds = [item.id, ...state.dataTypeIds];
+            }
+            const newState = {
+              ...state,
+              dataTypeIds: newDataTypeIds,
+            };
 
-              // update
-              onFacetChange(newState);
-            }}
-            value={item.id}
-            label={`${item.name} (${item.count})`}
-          >
-            {item.children.map(childItem => (
-              <FacetCheckbox
-                key={childItem.id}
-                nested
-                checked={state.dataSourceIds.indexOf(childItem.id) >= 0}
-                onChange={() => {
-                  let newDataSourceIds;
-                  if (state.dataSourceIds.indexOf(childItem.id) >= 0) {
-                    // switch off
-                    newDataSourceIds = state.dataSourceIds.filter(
-                      d => d !== childItem.id
-                    );
-                  } else {
-                    // switch on
-                    newDataSourceIds = [childItem.id, ...state.dataSourceIds];
-                  }
-                  const newState = {
-                    ...state,
-                    dataSourceIds: newDataSourceIds,
-                  };
+            // update
+            onFacetChange(newState);
+          }}
+          value={item.id}
+          label={`${item.name} (${item.count})`}
+        >
+          {item.children.map(childItem => (
+            <FacetCheckbox
+              key={childItem.id}
+              nested
+              checked={state.dataSourceIds.indexOf(childItem.id) >= 0}
+              onChange={() => {
+                let newDataSourceIds;
+                if (state.dataSourceIds.indexOf(childItem.id) >= 0) {
+                  // switch off
+                  newDataSourceIds = state.dataSourceIds.filter(
+                    d => d !== childItem.id
+                  );
+                } else {
+                  // switch on
+                  newDataSourceIds = [childItem.id, ...state.dataSourceIds];
+                }
+                const newState = {
+                  ...state,
+                  dataSourceIds: newDataSourceIds,
+                };
 
-                  // update
-                  onFacetChange(newState);
-                }}
-                value={childItem.id}
-                label={`${childItem.name} (${childItem.count})`}
-              />
-            ))}
-          </FacetCheckbox>
-        ))}
-      </FormGroup>
-    </FormControl>
-  </div>
+                // update
+                onFacetChange(newState);
+              }}
+              value={childItem.id}
+              label={`${childItem.name} (${childItem.count})`}
+            />
+          ))}
+        </FacetCheckbox>
+      ))}
+    </FormGroup>
+  </FormControl>
 );

--- a/src/public/target/facets/DataTypeAndSource.js
+++ b/src/public/target/facets/DataTypeAndSource.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import gql from 'graphql-tag';
+
+export const id = 'dataTypeAndSource';
+export const name = 'Data Type and Source';
+
+export const facetQuery = gql`
+  fragment targetDiseasesConnectionDataTypeAndSourceFragment on TargetDiseasesConnectionFacets {
+    dataTypeAndSource {
+      items {
+        id
+        name
+        count
+        children {
+          id
+          name
+          count
+        }
+      }
+    }
+  }
+`;
+
+export const FacetComponent = () => <div>data type and source</div>;

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -25,40 +25,37 @@ export const stateDefault = [];
 export const stateToInput = state =>
   state.length > 0 ? { efoIds: state } : null;
 
-export const FacetComponent = ({ state, data, onFacetChange }) => {
-  return (
-    <div>
-      <FormControl component="fieldset">
-        <FormLabel component="legend">{name}</FormLabel>
+export const FacetComponent = ({ state, data, onFacetChange }) => (
+  <div>
+    <FormControl component="fieldset">
+      <FormLabel component="legend">{name}</FormLabel>
+      <FormGroup>
+        {data.items.map(item => (
+          <FormControlLabel
+            key={item.id}
+            control={
+              <Checkbox
+                checked={state.indexOf(item.id) >= 0}
+                onChange={() => {
+                  let newState;
+                  if (state.indexOf(item.id) >= 0) {
+                    // switch off
+                    newState = state.filter(d => d !== item.id);
+                  } else {
+                    // switch on
+                    newState = [item.id, ...state];
+                  }
 
-        <FormGroup>
-          {data.items.map(item => (
-            <FormControlLabel
-              key={item.id}
-              control={
-                <Checkbox
-                  checked={state.indexOf(item.id) >= 0}
-                  onChange={() => {
-                    let newState;
-                    if (state.indexOf(item.id) >= 0) {
-                      // switch off
-                      newState = state.filter(d => d !== item.id);
-                    } else {
-                      // switch on
-                      newState = [item.id, ...state];
-                    }
-
-                    // update
-                    onFacetChange(newState);
-                  }}
-                  value={item.id}
-                />
-              }
-              label={`${item.name} (${item.count})`}
-            />
-          ))}
-        </FormGroup>
-      </FormControl>
-    </div>
-  );
-};
+                  // update
+                  onFacetChange(newState);
+                }}
+                value={item.id}
+              />
+            }
+            label={`${item.name} (${item.count})`}
+          />
+        ))}
+      </FormGroup>
+    </FormControl>
+  </div>
+);

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -28,7 +28,6 @@ export const stateToInput = state =>
 export const FacetComponent = ({ state, data, onFacetChange }) => (
   <div>
     <FormControl component="fieldset">
-      <FormLabel component="legend">{name}</FormLabel>
       <FormGroup>
         {data.items.map(item => (
           <FacetCheckbox

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
 

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -26,31 +26,29 @@ export const stateToInput = state =>
   state.length > 0 ? { efoIds: state } : null;
 
 export const FacetComponent = ({ state, data, onFacetChange }) => (
-  <div>
-    <FormControl component="fieldset">
-      <FormGroup>
-        {data.items.map(item => (
-          <FacetCheckbox
-            key={item.id}
-            checked={state.indexOf(item.id) >= 0}
-            onChange={() => {
-              let newState;
-              if (state.indexOf(item.id) >= 0) {
-                // switch off
-                newState = state.filter(d => d !== item.id);
-              } else {
-                // switch on
-                newState = [item.id, ...state];
-              }
+  <FormControl component="fieldset">
+    <FormGroup>
+      {data.items.map(item => (
+        <FacetCheckbox
+          key={item.id}
+          checked={state.indexOf(item.id) >= 0}
+          onChange={() => {
+            let newState;
+            if (state.indexOf(item.id) >= 0) {
+              // switch off
+              newState = state.filter(d => d !== item.id);
+            } else {
+              // switch on
+              newState = [item.id, ...state];
+            }
 
-              // update
-              onFacetChange(newState);
-            }}
-            value={item.id}
-            label={`${item.name} (${item.count})`}
-          />
-        ))}
-      </FormGroup>
-    </FormControl>
-  </div>
+            // update
+            onFacetChange(newState);
+          }}
+          value={item.id}
+          label={`${item.name} (${item.count})`}
+        />
+      ))}
+    </FormGroup>
+  </FormControl>
 );

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import gql from 'graphql-tag';
+
+export const id = 'therapeuticArea';
+export const name = 'Therapeutic Area';
+
+export const facetQuery = gql`
+  fragment targetDiseasesConnectionTherapeuticAreaFragment on TargetDiseasesConnectionFacets {
+    therapeuticArea {
+      items {
+        id
+        name
+        count
+      }
+    }
+  }
+`;
+
+export const FacetComponent = () => <div>therapeutic area</div>;

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import FormLabel from '@material-ui/core/FormLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
 export const id = 'therapeuticArea';
 export const name = 'Therapeutic Area';
@@ -16,4 +21,44 @@ export const facetQuery = gql`
   }
 `;
 
-export const FacetComponent = () => <div>therapeutic area</div>;
+export const stateDefault = [];
+export const stateToInput = state =>
+  state.length > 0 ? { efoIds: state } : null;
+
+export const FacetComponent = ({ state, data, onFacetChange }) => {
+  return (
+    <div>
+      <FormControl component="fieldset">
+        <FormLabel component="legend">{name}</FormLabel>
+
+        <FormGroup>
+          {data.items.map(item => (
+            <FormControlLabel
+              key={item.id}
+              control={
+                <Checkbox
+                  checked={state.indexOf(item.id) >= 0}
+                  onChange={() => {
+                    let newState;
+                    if (state.indexOf(item.id) >= 0) {
+                      // switch off
+                      newState = state.filter(d => d !== item.id);
+                    } else {
+                      // switch on
+                      newState = [item.id, ...state];
+                    }
+
+                    // update
+                    onFacetChange(newState);
+                  }}
+                  value={item.id}
+                />
+              }
+              label={`${item.name} (${item.count})`}
+            />
+          ))}
+        </FormGroup>
+      </FormControl>
+    </div>
+  );
+};

--- a/src/public/target/facets/TherapeuticArea.js
+++ b/src/public/target/facets/TherapeuticArea.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+
+import FacetCheckbox from '../../common/FacetCheckbox';
 
 export const id = 'therapeuticArea';
 export const name = 'Therapeutic Area';
@@ -31,27 +31,23 @@ export const FacetComponent = ({ state, data, onFacetChange }) => (
       <FormLabel component="legend">{name}</FormLabel>
       <FormGroup>
         {data.items.map(item => (
-          <FormControlLabel
+          <FacetCheckbox
             key={item.id}
-            control={
-              <Checkbox
-                checked={state.indexOf(item.id) >= 0}
-                onChange={() => {
-                  let newState;
-                  if (state.indexOf(item.id) >= 0) {
-                    // switch off
-                    newState = state.filter(d => d !== item.id);
-                  } else {
-                    // switch on
-                    newState = [item.id, ...state];
-                  }
+            checked={state.indexOf(item.id) >= 0}
+            onChange={() => {
+              let newState;
+              if (state.indexOf(item.id) >= 0) {
+                // switch off
+                newState = state.filter(d => d !== item.id);
+              } else {
+                // switch on
+                newState = [item.id, ...state];
+              }
 
-                  // update
-                  onFacetChange(newState);
-                }}
-                value={item.id}
-              />
-            }
+              // update
+              onFacetChange(newState);
+            }}
+            value={item.id}
             label={`${item.name} (${item.count})`}
           />
         ))}


### PR DESCRIPTION
This PR adds the classic associations to the target page. It depends on https://github.com/opentargets/platform-api/pull/39. Some iteration is likely, but this implements:
* faceting
* text search
* pagination (server-side)
* sorting (server-side)

Current screenshot:
<img width="1680" alt="Screenshot 2019-09-03 at 11 31 56" src="https://user-images.githubusercontent.com/7376272/64166265-a7cc7780-ce3e-11e9-8011-ad69c23c9f1f.png">
