### PR TITLE
Tweaks to classic associations tooltips

### DIFF
--- a/src/public/disease/ClassicAssociations.js
+++ b/src/public/disease/ClassicAssociations.js
@@ -215,6 +215,8 @@ class ClassicAssociations extends React.Component {
                 <Card elevation={0}>
                   <CardContent>
                     <ClassicAssociationsTable
+                      efoId={efoId}
+                      name={name}
                       rows={rows}
                       dataTypes={dataTypes}
                       sortBy={sortBy}

--- a/src/public/disease/ClassicAssociationsTable.js
+++ b/src/public/disease/ClassicAssociationsTable.js
@@ -149,23 +149,26 @@ const ClassicAssociationsTable = ({
               className={classes.row}
             >
               <TableCell
-                id={`target-cell-${row.target.id}`}
                 align="right"
                 padding="dense"
                 className={classNames(
                   classes.cellDiseaseName,
                   classes.cellEllipsis
                 )}
-                onMouseOver={() => {
-                  handleMouseover({
-                    id: row.target.id,
-                    symbol: row.target.symbol,
-                    score: row.score,
-                    disease: { efoId, name },
-                  });
-                }}
               >
-                {row.target.symbol}
+                <span
+                  id={`target-cell-${row.target.id}`}
+                  onMouseOver={() => {
+                    handleMouseover({
+                      id: row.target.id,
+                      symbol: row.target.symbol,
+                      score: row.score,
+                      disease: { efoId, name },
+                    });
+                  }}
+                >
+                  {row.target.symbol}
+                </span>
               </TableCell>
               <TableCell className={classes.cell}>
                 <div

--- a/src/public/disease/ClassicAssociationsTable.js
+++ b/src/public/disease/ClassicAssociationsTable.js
@@ -11,6 +11,9 @@ import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import TablePagination from '@material-ui/core/TablePagination';
 
+import withTooltip from '../common/withTooltip';
+import TooltipContent from './ClassicAssociationsTooltip';
+
 // TODO: Harmonise with HeatmapTable for component reuse
 
 const styles = theme => ({
@@ -74,6 +77,8 @@ const styles = theme => ({
 const ClassicAssociationsTable = ({
   classes,
   theme,
+  efoId,
+  name,
   rows,
   dataTypes,
   sortBy,
@@ -83,6 +88,7 @@ const ClassicAssociationsTable = ({
   totalCount,
   pageInfo,
   onPaginationChange,
+  handleMouseover,
 }) => {
   const colorScale = d3
     .scaleLinear()
@@ -143,12 +149,21 @@ const ClassicAssociationsTable = ({
               className={classes.row}
             >
               <TableCell
+                id={`target-cell-${row.target.id}`}
                 align="right"
                 padding="dense"
                 className={classNames(
                   classes.cellDiseaseName,
                   classes.cellEllipsis
                 )}
+                onMouseOver={() => {
+                  handleMouseover({
+                    id: row.target.id,
+                    symbol: row.target.symbol,
+                    score: row.score,
+                    disease: { efoId, name },
+                  });
+                }}
               >
                 {row.target.symbol}
               </TableCell>
@@ -199,6 +214,11 @@ const ClassicAssociationsTable = ({
   );
 };
 
-export default withStyles(styles, { withTheme: true })(
-  ClassicAssociationsTable
+const tooltipElementFinder = ({ id }) =>
+  document.querySelector(`#target-cell-${id}`);
+
+export default withTooltip(
+  withStyles(styles, { withTheme: true })(ClassicAssociationsTable),
+  TooltipContent,
+  tooltipElementFinder
 );

--- a/src/public/disease/ClassicAssociationsTooltip.js
+++ b/src/public/disease/ClassicAssociationsTooltip.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+import { Link, significantFigures } from 'ot-ui';
+
+const TooltipContent = ({ data }) => (
+  <Card>
+    <CardContent>
+      <Typography align="center">
+        <strong>{data.symbol}</strong>
+        <br />
+        association score: {significantFigures(data.score)}
+        <br />
+        <Link to={`/target/${data.id}`}>Target profile</Link>
+        <br />
+        <Link to={`/target/${data.id}/classic-associations`}>
+          Target associations
+        </Link>
+        <br />
+        <Link to={`/evidence/${data.id}/${data.disease.efoId}`}>
+          Association evidence
+        </Link>
+      </Typography>
+    </CardContent>
+  </Card>
+);
+
+export default TooltipContent;

--- a/src/public/target/ClassicAssociations.js
+++ b/src/public/target/ClassicAssociations.js
@@ -257,6 +257,8 @@ class ClassicAssociations extends React.Component {
                     {/* table view */}
                     {tab === 'table' && (
                       <ClassicAssociationsTable
+                        ensgId={ensgId}
+                        symbol={symbol}
                         rows={rows}
                         dataTypes={dataTypes}
                         sortBy={sortBy}

--- a/src/public/target/ClassicAssociationsBubbles.js
+++ b/src/public/target/ClassicAssociationsBubbles.js
@@ -2,13 +2,9 @@ import React from 'react';
 import { withContentRect } from 'react-measure';
 import * as d3 from 'd3';
 import withTheme from '@material-ui/core/styles/withTheme';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';
-
-import { Link, significantFigures } from 'ot-ui';
 
 import withTooltip from '../common/withTooltip';
+import TooltipContent from './ClassicAssociationsTooltip';
 
 const getTherapeuticAreaTree = ({ ensgId, symbol, data, efo, diameter }) => {
   const efoById = new Map(efo.nodes.map(d => [d.id, d]));
@@ -235,24 +231,6 @@ class ClassicAssociationsBubbles extends React.Component {
 
 const tooltipElementFinder = ({ uniqueId }) =>
   document.querySelector(`#tree-node-${uniqueId}`);
-
-const TooltipContent = ({ data }) => (
-  <Card>
-    <CardContent>
-      <Typography align="center">
-        <strong>{data.name}</strong>
-        <br />
-        association score: {significantFigures(data.score)}
-        <br />
-        <Link to={`/disease/${data.id}`}>Disease profile</Link>
-        <br />
-        <Link to={`/evidence/${data.target.ensgId}/${data.id}`}>
-          Association evidence
-        </Link>
-      </Typography>
-    </CardContent>
-  </Card>
-);
 
 export default withTooltip(
   withTheme()(withContentRect('bounds')(ClassicAssociationsBubbles)),

--- a/src/public/target/ClassicAssociationsDAG.js
+++ b/src/public/target/ClassicAssociationsDAG.js
@@ -3,13 +3,9 @@ import { withContentRect } from 'react-measure';
 import * as d3Base from 'd3';
 import * as d3DagBase from 'd3-dag';
 import withTheme from '@material-ui/core/styles/withTheme';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';
-
-import { Link, significantFigures } from 'ot-ui';
 
 import withTooltip from '../common/withTooltip';
+import TooltipContent from './ClassicAssociationsTooltip';
 
 const d3 = Object.assign({}, d3Base, d3DagBase);
 
@@ -382,24 +378,6 @@ class ClassicAssociationsDAG extends React.Component {
 
 const tooltipElementFinder = ({ id }) =>
   document.querySelector(`#dag-node-${id}`);
-
-const TooltipContent = ({ data }) => (
-  <Card>
-    <CardContent>
-      <Typography align="center">
-        <strong>{data.name}</strong>
-        <br />
-        association score: {significantFigures(data.score)}
-        <br />
-        <Link to={`/disease/${data.id}`}>Disease profile</Link>
-        <br />
-        <Link to={`/evidence/${data.target.ensgId}/${data.id}`}>
-          Association evidence
-        </Link>
-      </Typography>
-    </CardContent>
-  </Card>
-);
 
 export default withTooltip(
   withTheme()(withContentRect('bounds')(ClassicAssociationsDAG)),

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -149,23 +149,26 @@ const ClassicAssociationsTable = ({
               className={classes.row}
             >
               <TableCell
-                id={`disease-cell-${row.disease.id}`}
                 align="right"
                 padding="dense"
                 className={classNames(
                   classes.cellDiseaseName,
                   classes.cellEllipsis
                 )}
-                onMouseOver={() => {
-                  handleMouseover({
-                    id: row.disease.id,
-                    name: row.disease.name,
-                    score: row.score,
-                    target: { ensgId, symbol },
-                  });
-                }}
               >
-                {row.disease.name}
+                <span
+                  id={`disease-cell-${row.disease.id}`}
+                  onMouseOver={() => {
+                    handleMouseover({
+                      id: row.disease.id,
+                      name: row.disease.name,
+                      score: row.score,
+                      target: { ensgId, symbol },
+                    });
+                  }}
+                >
+                  {row.disease.name}
+                </span>
               </TableCell>
               <TableCell className={classes.cell}>
                 <div

--- a/src/public/target/ClassicAssociationsTable.js
+++ b/src/public/target/ClassicAssociationsTable.js
@@ -11,6 +11,9 @@ import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import TablePagination from '@material-ui/core/TablePagination';
 
+import withTooltip from '../common/withTooltip';
+import TooltipContent from './ClassicAssociationsTooltip';
+
 // TODO: Harmonise with HeatmapTable for component reuse
 
 const styles = theme => ({
@@ -74,6 +77,8 @@ const styles = theme => ({
 const ClassicAssociationsTable = ({
   classes,
   theme,
+  ensgId,
+  symbol,
   rows,
   dataTypes,
   sortBy,
@@ -83,6 +88,7 @@ const ClassicAssociationsTable = ({
   totalCount,
   pageInfo,
   onPaginationChange,
+  handleMouseover,
 }) => {
   const colorScale = d3
     .scaleLinear()
@@ -143,12 +149,21 @@ const ClassicAssociationsTable = ({
               className={classes.row}
             >
               <TableCell
+                id={`disease-cell-${row.disease.id}`}
                 align="right"
                 padding="dense"
                 className={classNames(
                   classes.cellDiseaseName,
                   classes.cellEllipsis
                 )}
+                onMouseOver={() => {
+                  handleMouseover({
+                    id: row.disease.id,
+                    name: row.disease.name,
+                    score: row.score,
+                    target: { ensgId, symbol },
+                  });
+                }}
               >
                 {row.disease.name}
               </TableCell>
@@ -199,6 +214,11 @@ const ClassicAssociationsTable = ({
   );
 };
 
-export default withStyles(styles, { withTheme: true })(
-  ClassicAssociationsTable
+const tooltipElementFinder = ({ id }) =>
+  document.querySelector(`#disease-cell-${id}`);
+
+export default withTooltip(
+  withStyles(styles, { withTheme: true })(ClassicAssociationsTable),
+  TooltipContent,
+  tooltipElementFinder
 );

--- a/src/public/target/ClassicAssociationsTooltip.js
+++ b/src/public/target/ClassicAssociationsTooltip.js
@@ -15,6 +15,10 @@ const TooltipContent = ({ data }) => (
         <br />
         <Link to={`/disease/${data.id}`}>Disease profile</Link>
         <br />
+        <Link to={`/disease/${data.id}/classic-associations`}>
+          Disease associations
+        </Link>
+        <br />
         <Link to={`/evidence/${data.target.ensgId}/${data.id}`}>
           Association evidence
         </Link>

--- a/src/public/target/ClassicAssociationsTooltip.js
+++ b/src/public/target/ClassicAssociationsTooltip.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+import { Link, significantFigures } from 'ot-ui';
+
+const TooltipContent = ({ data }) => (
+  <Card>
+    <CardContent>
+      <Typography align="center">
+        <strong>{data.name}</strong>
+        <br />
+        association score: {significantFigures(data.score)}
+        <br />
+        <Link to={`/disease/${data.id}`}>Disease profile</Link>
+        <br />
+        <Link to={`/evidence/${data.target.ensgId}/${data.id}`}>
+          Association evidence
+        </Link>
+      </Typography>
+    </CardContent>
+  </Card>
+);
+
+export default TooltipContent;


### PR DESCRIPTION
This PR:
* adds tooltips to both the classic associations heatmap tables
* abstracts out the tooltip content
