### PR TITLE
Handle GXA widget errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "d3-dag": "^0.2.6",
     "d3-selection": "^1.4.0",
     "dc": "^3.0.8",
-    "expression-atlas-heatmap-highcharts": "^5.2.4",
+    "expression-atlas-heatmap-highcharts": "^5.3.1",
     "fg-loadcss": "^2.0.1",
     "file-saver": "^1.3.8",
     "graphql": "^14.0.2",

--- a/src/public/target/sections/Expression/Section.js
+++ b/src/public/target/sections/Expression/Section.js
@@ -21,7 +21,7 @@ class Section extends Component {
           <Tab value="gtex" label="GTEx variability" />
         </Tabs>
         {tab === 'summary' && <SummaryTab ensgId={ensgId} symbol={symbol} />}
-        {tab === 'atlas' && <AtlasTab ensgId={ensgId} />}
+        {tab === 'atlas' && <AtlasTab ensgId={ensgId} symbol={symbol} />}
         {tab === 'gtex' && <GtexTab symbol={symbol} />}
       </Fragment>
     );

--- a/src/public/target/sections/Expression/custom/AtlasTab.js
+++ b/src/public/target/sections/Expression/custom/AtlasTab.js
@@ -6,7 +6,40 @@ const ExpressionAtlasHeatmap = lazy(() =>
   import('expression-atlas-heatmap-highcharts')
 );
 
-const AtlasTab = ({ ensgId }) => {
+class AtlasHandler extends React.Component {
+  state = {
+    hasError: false,
+  };
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    if (error) {
+      return { hasError: true };
+    } else {
+      return null;
+    }
+  }
+  render() {
+    const { ensgId, symbol } = this.props;
+    const { hasError } = this.state;
+    return hasError ? (
+      <Typography color="error">
+        There was an error loading the Expression Atlas plugin for {symbol}.
+      </Typography>
+    ) : (
+      <Suspense fallback={<div>Loading...</div>}>
+        <ExpressionAtlasHeatmap
+          query={{
+            species: 'homo sapiens',
+            gene: ensgId,
+            target: 'heatmapContainer',
+          }}
+        />
+      </Suspense>
+    );
+  }
+}
+
+const AtlasTab = ({ ensgId, symbol }) => {
   return (
     <Fragment>
       <Typography variant="caption">
@@ -17,12 +50,8 @@ const AtlasTab = ({ ensgId }) => {
         >
           Expression Atlas
         </Link>
+        <AtlasHandler {...{ ensgId, symbol }} />
       </Typography>
-      <Suspense fallback={<div>Loading...</div>}>
-        <ExpressionAtlasHeatmap
-          query={{ species: 'homo sapiens', gene: ensgId }}
-        />
-      </Suspense>
     </Fragment>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2985,7 +2985,7 @@ color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
-color@^3.0.0, color@^3.1.1:
+color@^3.0.0, color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
   dependencies:
@@ -4886,32 +4886,32 @@ expression-atlas-disclaimers@1.1.0:
   dependencies:
     react "^16.8.6"
 
-expression-atlas-heatmap-highcharts@^5.2.4:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/expression-atlas-heatmap-highcharts/-/expression-atlas-heatmap-highcharts-5.2.6.tgz#d69dab85b67e19aa2708dba5d9c2b63dfb451573"
+expression-atlas-heatmap-highcharts@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/expression-atlas-heatmap-highcharts/-/expression-atlas-heatmap-highcharts-5.3.1.tgz#26207be440516a0f45c7d920db5128e0177b0b17"
   dependencies:
     anatomogram "^2.1.2"
-    color "^3.1.1"
+    color "^3.1.2"
     downloadjs "^1.4.7"
     expression-atlas-disclaimers "1.1.0"
     expression-atlas-number-format "^3.1.0"
     he "^1.2.0"
     highcharts "^6.2.0"
     highcharts-custom-events "^2.2.6"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     object-hash "^1.3.1"
     prop-types "^15.7.2"
-    rc-slider "^8.6.9"
+    rc-slider "^8.7.1"
     react "^16.8.6"
     react-bootstrap "^0.32.4"
     react-debounce-render "^5.0.0"
     react-dom "^16.8.6"
-    react-ga "^2.5.7"
-    react-highcharts "^16.0.2"
+    react-ga "^2.6.0"
+    react-highcharts "^16.1.0"
     react-refetch "^2.0.3"
     sanitize-html "^1.20.1"
-    styled-components "^4.2.0"
-    uncontrollable "^6.1.0"
+    styled-components "^4.4.0"
+    uncontrollable "^7.0.1"
     urijs "^1.19.1"
 
 expression-atlas-number-format@^3.1.0:
@@ -9191,7 +9191,6 @@ osenv@0, osenv@^0.1.4:
 ot-ui@^0.0.99:
   version "0.0.99"
   resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.99.tgz#f3ba15a7f18d3a28d38c15754501bac3de50ef5b"
-  integrity sha512-iUEYMwSAVxenEWYOVUfgsIBOY5KzNZ3Q6ZTh62luSJYZ1k33YC2QlkNtVU2mI86PNuGVbaYEB+n4BMSlmqULdg==
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -10458,16 +10457,17 @@ rc-animate@2.x:
     rc-util "^4.8.0"
     react-lifecycles-compat "^3.0.4"
 
-rc-slider@^8.6.9:
-  version "8.6.13"
-  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.13.tgz#88a8150c2dda6709f3f119135de11fba80af765b"
+rc-slider@^8.7.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.7.1.tgz#9ed07362dc93489a38e654b21b8122ad70fd3c42"
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.5"
     prop-types "^15.5.4"
     rc-tooltip "^3.7.0"
     rc-util "^4.0.4"
-    shallowequal "^1.0.1"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.1.0"
     warning "^4.0.3"
 
 rc-tooltip@^3.7.0:
@@ -10648,7 +10648,7 @@ react-fast-compare@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
 
-react-ga@^2.5.7:
+react-ga@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.6.0.tgz#c3fe830ead2ad25117e1d33280d9698de9b28496"
 
@@ -10661,9 +10661,9 @@ react-helmet@^5.2.0:
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
-react-highcharts@^16.0.2:
-  version "16.0.2"
-  resolved "https://registry.yarnpkg.com/react-highcharts/-/react-highcharts-16.0.2.tgz#7bdae039f9abb3f753ba88b6578d52630c18537a"
+react-highcharts@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/react-highcharts/-/react-highcharts-16.1.0.tgz#aa2d451171197462e07fa8652a42bac43da6068a"
   dependencies:
     highcharts "^6.0.4"
 
@@ -11649,7 +11649,7 @@ shallowequal@^0.2.2:
   dependencies:
     lodash.keys "^3.1.2"
 
-shallowequal@^1.0.1:
+shallowequal@^1.0.1, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
@@ -12233,6 +12233,24 @@ style-loader@0.23.1:
 styled-components@^4.2.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.2.tgz#4ca81918c812d3006f60ac5fdec7d6b64a9509cc"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+styled-components@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.0.tgz#4e381e2dab831d0e6ea431c2840a96323e84e21b"
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.0.0"
@@ -12929,9 +12947,9 @@ uncontrollable@^5.0.0:
   dependencies:
     invariant "^2.2.4"
 
-uncontrollable@^6.1.0:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-6.2.3.tgz#e7dba0d746e075122ed178f27ad2354d343196c7"
+uncontrollable@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.0.1.tgz#9451ecd13ed480c3e8318c2ee5f0f7522b13b33c"
   dependencies:
     "@babel/runtime" "^7.4.5"
     invariant "^2.2.4"


### PR DESCRIPTION
Fixes https://github.com/opentargets/platform/issues/732.

This PR:
* upgrades GXA widget so that errors are fixed
* adds a handler so that if GXA widget fails in future, it doesn't crash the site