### PR TITLE
Lf adverse events

### DIFF
--- a/src/public/drug/sections/AdverseEvents/Description.js
+++ b/src/public/drug/sections/AdverseEvents/Description.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    TODO: Write a description component for <strong>{name}</strong>.
+    Adverse events for <strong>{name}</strong>.
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/AdverseEvents/Section.js
+++ b/src/public/drug/sections/AdverseEvents/Section.js
@@ -59,8 +59,13 @@ const Section = ({ classes, data, name }) => {
       professionals to the FDA Adverse Event Reporting System (FAERS). The list
       only contains adverse events with a log likelihood ratio above a critical
       value (CV) threshold - see our{' '}
-      <Link to="#">adverse event report documentation page</Link> for more
-      information.
+      <Link
+        to="https://docs.targetvalidation.org/getting-started/getting-started/drug-summary/pharmacovigilance"
+        external
+      >
+        adverse event report documentation page
+      </Link>{' '}
+      for more information.
       <DataDownloader
         tableHeaders={columns}
         rows={data.rows}

--- a/src/public/drug/sections/AdverseEvents/Section.js
+++ b/src/public/drug/sections/AdverseEvents/Section.js
@@ -1,37 +1,81 @@
 import React from 'react';
+import _ from 'lodash';
+import withStyles from '@material-ui/core/styles/withStyles';
 
-import { Link, OtTableRF } from 'ot-ui';
+import { Link, OtTableRF, DataDownloader } from 'ot-ui';
+import LevelBar from '../../../common/LevelBar';
 
-const columns = [
-  {
-    id: 'event',
-    label: 'Adverse event',
+const styles = theme => ({
+  levelBarContainer: {
+    display: 'flex',
+    alignItems: 'center',
   },
-  {
-    id: 'count',
-    label: 'Number of reported events',
+  levelBar: {
+    backgroundColor: theme.palette.primary.main,
+    borderRight: `1px solid ${theme.palette.primary.main}`,
+    height: '10px',
+    marginRight: '5px',
   },
-  {
-    id: 'llr',
-    label: 'Log likelihood ratio',
-  },
-];
+});
 
-const Section = ({ data }) => (
-  <React.Fragment>
-    A list of post-marketing adverse events submitted by healthcare
-    professionals to the FDA Adverse Event Reporting System (FAERS). The list
-    only contains adverse events with a log likelihood ratio above a critical
-    value (CV) threshold - see our{' '}
-    <Link to="#">adverse event report documentation page</Link> for more
-    information.
-    <OtTableRF
-      loading={false}
-      error={false}
-      columns={columns}
-      data={data.rows}
-    />
-  </React.Fragment>
-);
+const Section = ({ classes, data, name }) => {
+  const maxLlr = data.rows[0].llr;
+  const columns = [
+    {
+      id: 'event',
+      label: 'Adverse event',
+      renderCell: d => _.upperFirst(d.event),
+      width: '35%',
+    },
+    {
+      id: 'count',
+      label: 'Number of reported events',
+      width: '15%',
+    },
+    {
+      id: 'llr',
+      label: `Log likelihood ratio (CV = ${data.critval})`,
+      renderCell: d => {
+        const w = ((d.llr / maxLlr) * 85).toFixed(2); // scale to max 85% of the width to allows space for label
+        return (
+          <div className={classes.levelBarContainer}>
+            <div
+              className={classes.levelBar}
+              style={{
+                width: `${w}%`,
+              }}
+            ></div>
+            <div>{d.llr.toFixed(2)}</div>
+          </div>
+        );
+      },
+      width: '50%',
+    },
+  ];
 
-export default Section;
+  return (
+    <React.Fragment>
+      A list of post-marketing adverse events submitted by healthcare
+      professionals to the FDA Adverse Event Reporting System (FAERS). The list
+      only contains adverse events with a log likelihood ratio above a critical
+      value (CV) threshold - see our{' '}
+      <Link to="#">adverse event report documentation page</Link> for more
+      information.
+      <DataDownloader
+        tableHeaders={columns}
+        rows={data.rows}
+        fileStem={`${name}-pharmacovigilance`}
+      />
+      <OtTableRF
+        loading={false}
+        error={false}
+        columns={columns}
+        data={data.rows}
+        pageSize={data.rows.length || 25}
+      />
+    </React.Fragment>
+  );
+};
+
+// export default Section;
+export default withStyles(styles)(Section);

--- a/src/public/drug/sections/AdverseEvents/Section.js
+++ b/src/public/drug/sections/AdverseEvents/Section.js
@@ -1,8 +1,36 @@
 import React from 'react';
 
-const Section = ({ name }) => (
+import { Link, OtTableRF } from 'ot-ui';
+
+const columns = [
+  {
+    id: 'event',
+    label: 'Adverse event',
+  },
+  {
+    id: 'count',
+    label: 'Number of reported events',
+  },
+  {
+    id: 'llr',
+    label: 'Log likelihood ratio',
+  },
+];
+
+const Section = ({ data }) => (
   <React.Fragment>
-    TODO: Write a section component for <strong>{name}</strong>.
+    A list of post-marketing adverse events submitted by healthcare
+    professionals to the FDA Adverse Event Reporting System (FAERS). The list
+    only contains adverse events with a log likelihood ratio above a critical
+    value (CV) threshold - see our{' '}
+    <Link to="#">adverse event report documentation page</Link> for more
+    information.
+    <OtTableRF
+      loading={false}
+      error={false}
+      columns={columns}
+      data={data.rows}
+    />
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/AdverseEvents/Summary.js
+++ b/src/public/drug/sections/AdverseEvents/Summary.js
@@ -1,7 +1,9 @@
 import React from 'react';
 
-const Summary = ({ name }) => (
-  <React.Fragment>TODO: Write a summary</React.Fragment>
+const Summary = ({ eventsCount }) => (
+  <React.Fragment>
+    {eventsCount} adverse event{eventsCount !== 1 ? 's' : ''}
+  </React.Fragment>
 );
 
 export default Summary;

--- a/src/public/drug/sections/AdverseEvents/index.js
+++ b/src/public/drug/sections/AdverseEvents/index.js
@@ -3,7 +3,7 @@ import { loader } from 'graphql.macro';
 export const id = 'adverseEvents';
 export const name = 'Adverse Events';
 
-export const hasSummaryData = () => true; // TODO: override this
+export const hasSummaryData = ({ eventsCount }) => eventsCount > 0;
 
 export const summaryQuery = loader('./summaryQuery.gql');
 export const sectionQuery = loader('./sectionQuery.gql');

--- a/src/public/drug/sections/AdverseEvents/index.js
+++ b/src/public/drug/sections/AdverseEvents/index.js
@@ -1,7 +1,12 @@
+import { loader } from 'graphql.macro';
+
 export const id = 'adverseEvents';
 export const name = 'Adverse Events';
 
 export const hasSummaryData = () => true; // TODO: override this
+
+export const summaryQuery = loader('./summaryQuery.gql');
+export const sectionQuery = loader('./sectionQuery.gql');
 
 export { default as DescriptionComponent } from './Description';
 export { default as SummaryComponent } from './Summary';

--- a/src/public/drug/sections/AdverseEvents/index.js
+++ b/src/public/drug/sections/AdverseEvents/index.js
@@ -1,7 +1,7 @@
 import { loader } from 'graphql.macro';
 
 export const id = 'adverseEvents';
-export const name = 'Adverse Events';
+export const name = 'Pharmacovigilance';
 
 export const hasSummaryData = ({ eventsCount }) => eventsCount > 0;
 

--- a/src/public/drug/sections/AdverseEvents/sectionQuery.gql
+++ b/src/public/drug/sections/AdverseEvents/sectionQuery.gql
@@ -1,0 +1,14 @@
+query AdverseEventsSectionQuery($chemblId: String!) {
+  drug(chemblId: $chemblId) {
+    id
+    details{
+      adverseEvents{
+        rows{
+          event
+          count
+          llr
+        }
+      }
+    }
+  }
+}

--- a/src/public/drug/sections/AdverseEvents/sectionQuery.gql
+++ b/src/public/drug/sections/AdverseEvents/sectionQuery.gql
@@ -3,6 +3,7 @@ query AdverseEventsSectionQuery($chemblId: String!) {
     id
     details{
       adverseEvents{
+        critval
         rows{
           event
           count

--- a/src/public/drug/sections/AdverseEvents/summaryQuery.gql
+++ b/src/public/drug/sections/AdverseEvents/summaryQuery.gql
@@ -1,0 +1,10 @@
+fragment drugAdverseEventsFragment on DrugSummaries {
+  adverseEvents{
+    critval
+    eventsCount
+    sources{
+      name
+      url
+    }
+  }
+}


### PR DESCRIPTION
New adverse events visualisation.
Depends on corresponding API updates (which in turn depend on production API 19.11): https://github.com/opentargets/platform-api/pull/47

Marking as draft as it still needs final documentation URL (Section.js line 62)