### PR TITLE
Text mining: cap relevance value

### DIFF
--- a/src/public/evidenceByDatatype/sections/TextMining/Section.js
+++ b/src/public/evidenceByDatatype/sections/TextMining/Section.js
@@ -36,7 +36,7 @@ const columns = [
     label: 'Relevance',
     style: { verticalAlign: 'top', paddingTop: '7px' },
     width: '10%',
-    renderCell: d => <LevelBar value={d.relevance * 100} />,
+    renderCell: d => <LevelBar value={Math.min(d.relevance, 1) * 100} />,
   },
 ];
 


### PR DESCRIPTION
This PR adds a small fix for the display of text mining relevance field (which is being capped)