### PR TITLE
Lf avatar initials

### DIFF
--- a/src/public/common/MiniWidget.js
+++ b/src/public/common/MiniWidget.js
@@ -81,6 +81,7 @@ const styles = theme => ({
 const MiniWidget = ({
   classes,
   name,
+  shortName,
   icon,
   loading,
   error,
@@ -111,10 +112,11 @@ const MiniWidget = ({
               [classes.avatarError]: error,
             })}
           >
-            {name
-              .split(' ')
-              .map(d => d[0].toUpperCase())
-              .join('')}
+            {shortName ||
+              name
+                .split(' ')
+                .map(d => d[0].toUpperCase())
+                .join('')}
           </Avatar>
         }
         action={null}

--- a/src/public/common/SectionAvatar.js
+++ b/src/public/common/SectionAvatar.js
@@ -16,7 +16,7 @@ const styles = theme => ({
   },
 });
 
-const SectionAvatar = ({ classes, name, icon, hasData, error }) => (
+const SectionAvatar = ({ classes, name, shortName, icon, hasData, error }) => (
   <Avatar
     className={classNames({
       [classes.avatar]: true,
@@ -24,10 +24,11 @@ const SectionAvatar = ({ classes, name, icon, hasData, error }) => (
       [classes.avatarError]: error,
     })}
   >
-    {name
-      .split(' ')
-      .map(d => d[0].toUpperCase())
-      .join('')}
+    {shortName ||
+      name
+        .split(' ')
+        .map(d => d[0].toUpperCase())
+        .join('')}
   </Avatar>
 );
 

--- a/src/public/common/SectionPanel.js
+++ b/src/public/common/SectionPanel.js
@@ -50,6 +50,7 @@ class SectionPanel extends React.Component {
       classes,
       id,
       name,
+      shortName,
       icon,
       entity,
       entitySectionsAccessor,
@@ -67,7 +68,9 @@ class SectionPanel extends React.Component {
           <Card elevation={0}>
             <CardHeader
               className={classes.cardHeader}
-              avatar={<SectionAvatar {...{ name, icon, hasData, error }} />}
+              avatar={
+                <SectionAvatar {...{ name, shortName, icon, hasData, error }} />
+              }
               action={null}
               title={
                 <Typography

--- a/src/public/disease/sections/Phenotypes/index.js
+++ b/src/public/disease/sections/Phenotypes/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'phenotypes';
 export const name = 'Phenotypes';
+export const shortName = 'Ph';
 
 export const hasSummaryData = ({ phenotypesCount }) => phenotypesCount > 0;
 

--- a/src/public/disease/sections/Phenotypes/index.js
+++ b/src/public/disease/sections/Phenotypes/index.js
@@ -2,7 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'phenotypes';
 export const name = 'Phenotypes';
-export const shortName = 'Ph';
+export const shortName = 'PH';
 
 export const hasSummaryData = ({ phenotypesCount }) => phenotypesCount > 0;
 

--- a/src/public/drug/sections/MechanismsOfAction/index.js
+++ b/src/public/drug/sections/MechanismsOfAction/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'mechanismsOfAction';
 export const name = 'Mechanisms of Action';
+export const shortName = 'MA';
 
 export const hasSummaryData = ({ uniqueActionTypes, uniqueTargetTypes }) =>
   uniqueActionTypes.length > 0 && uniqueTargetTypes.length > 0;

--- a/src/public/evidenceByDatatype/sections/Pathways/index.js
+++ b/src/public/evidenceByDatatype/sections/Pathways/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'pathways';
 export const name = 'Pathways and Systems Biology';
+export const shortName = 'SB';
 
 const datasources = ['reactome', 'slapenrich', 'progeny', 'crispr', 'sysBio'];
 

--- a/src/public/target/sections/Pathways/index.js
+++ b/src/public/target/sections/Pathways/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'pathways';
 export const name = 'Pathways';
+export const shortName = 'Pw';
 
 export const hasSummaryData = ({ count }) => count > 0;
 

--- a/src/public/target/sections/Pathways/index.js
+++ b/src/public/target/sections/Pathways/index.js
@@ -2,7 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'pathways';
 export const name = 'Pathways';
-export const shortName = 'Pw';
+export const shortName = 'PW';
 
 export const hasSummaryData = ({ count }) => count > 0;
 

--- a/src/public/target/sections/ProteinInteractions/index.js
+++ b/src/public/target/sections/ProteinInteractions/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'proteinInteractions';
 export const name = 'Protein Interactions';
+export const shortName = 'PP';
 
 export const hasSummaryData = data =>
   data.ppi > 0 || data.pathways > 0 || data.enzymeSubstrate > 0;

--- a/src/public/target/sections/Tractability/index.js
+++ b/src/public/target/sections/Tractability/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'tractability';
 export const name = 'Tractability';
+export const shortName = 'Tr';
 
 export const hasSummaryData = data =>
   data.hasAntibodyTractabilityAssessment ||

--- a/src/public/target/sections/Tractability/index.js
+++ b/src/public/target/sections/Tractability/index.js
@@ -2,7 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'tractability';
 export const name = 'Tractability';
-export const shortName = 'Tr';
+export const shortName = 'TR';
 
 export const hasSummaryData = data =>
   data.hasAntibodyTractabilityAssessment ||

--- a/src/public/target/sections/Variation/index.js
+++ b/src/public/target/sections/Variation/index.js
@@ -2,6 +2,7 @@ import { loader } from 'graphql.macro';
 
 export const id = 'variation';
 export const name = 'Variation and Genomic Context';
+export const shortName = 'V';
 
 export const hasSummaryData = ({ common, rare }) =>
   common.variantsCount > 0 || rare.mutationsCount > 0;


### PR DESCRIPTION
This PR adds the functionality to specify an optional short name for page sections: the `shortName` is displayed in the section avatar (i.e. the blue bubble).

By default the avatar bubble is otherwise populated with the initials of the section name. 

Issue https://github.com/opentargets/platform/issues/761