### PR TITLE
Lf indication 773

### DIFF
--- a/src/public/drug/sections/LinkedDiseases/Description.js
+++ b/src/public/drug/sections/LinkedDiseases/Description.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    Diseases associated with <strong>{name}</strong>.
+    <strong>{name}</strong> has been indicated for the following diseases.
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/LinkedDiseases/Section.js
+++ b/src/public/drug/sections/LinkedDiseases/Section.js
@@ -7,6 +7,7 @@ const columns = [
     id: 'name',
     label: 'Name',
     renderCell: d => <Link to={`/disease/${d.id}`}>{d.name}</Link>,
+    width: '20%',
   },
   {
     id: 'therapeuticAreas',
@@ -18,6 +19,11 @@ const columns = [
           <Link to={`/disease/${t.id}`}>{t.name}</Link>
         </React.Fragment>
       )),
+  },
+  {
+    id: 'maxPhase',
+    label: 'Max phase',
+    width: '15%',
   },
 ];
 

--- a/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
+++ b/src/public/drug/sections/LinkedDiseases/sectionQuery.gql
@@ -6,6 +6,7 @@ query LinkedDiseasesSectionQuery($chemblId: String!) {
         rows {
           name
           id
+          maxPhase
           therapeuticAreas {
             id
             name


### PR DESCRIPTION
This short PR completes the disease table on the drug page by adding a "max phase" column.
The data from the API uses the recently added indications fields.
It depends on https://github.com/opentargets/platform-api/pull/51