### PR TITLE
Lf drugfix 798

### DIFF
--- a/src/public/drug/sections/AdverseEvents/Description.js
+++ b/src/public/drug/sections/AdverseEvents/Description.js
@@ -1,8 +1,18 @@
 import React from 'react';
+import { Link } from 'ot-ui';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    Adverse events for <strong>{name}</strong>.
+    Post-marketing adverse events for <strong>{name}</strong> submitted by
+    healthcare professionals to the FDA Adverse Event Reporting System (FAERS)
+    with a log likelihood ratio above a critical value (CV) threshold - see our{' '}
+    <Link
+      to="https://docs.targetvalidation.org/getting-started/getting-started/drug-summary/pharmacovigilance"
+      external
+    >
+      adverse event report documentation page
+    </Link>{' '}
+    for more information.
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/AdverseEvents/Section.js
+++ b/src/public/drug/sections/AdverseEvents/Section.js
@@ -55,17 +55,6 @@ const Section = ({ classes, data, name }) => {
 
   return (
     <React.Fragment>
-      A list of post-marketing adverse events submitted by healthcare
-      professionals to the FDA Adverse Event Reporting System (FAERS). The list
-      only contains adverse events with a log likelihood ratio above a critical
-      value (CV) threshold - see our{' '}
-      <Link
-        to="https://docs.targetvalidation.org/getting-started/getting-started/drug-summary/pharmacovigilance"
-        external
-      >
-        adverse event report documentation page
-      </Link>{' '}
-      for more information.
       <DataDownloader
         tableHeaders={columns}
         rows={data.rows}

--- a/src/public/drug/sections/LinkedDiseases/Section.js
+++ b/src/public/drug/sections/LinkedDiseases/Section.js
@@ -14,10 +14,9 @@ const columns = [
     label: 'Therapeutic Areas',
     renderCell: d =>
       d.therapeuticAreas.map((t, i) => (
-        <React.Fragment key={i}>
-          {i > 0 ? <br /> : null}
+        <div key={i}>
           <Link to={`/disease/${t.id}`}>{t.name}</Link>
-        </React.Fragment>
+        </div>
       )),
   },
   {

--- a/src/public/drug/sections/LinkedDiseases/Section.js
+++ b/src/public/drug/sections/LinkedDiseases/Section.js
@@ -15,7 +15,7 @@ const columns = [
     renderCell: d =>
       d.therapeuticAreas.map((t, i) => (
         <React.Fragment key={i}>
-          {i > 0 ? ', ' : null}
+          {i > 0 ? <br /> : null}
           <Link to={`/disease/${t.id}`}>{t.name}</Link>
         </React.Fragment>
       )),


### PR DESCRIPTION
This short PR fixes two small issues on the drugs page:
1. Updates the pharmacovigilance description (moved from the panel content into the top part) as per issue https://github.com/opentargets/platform/issues/798
2. Breaks into lines the TAs in the diseases table as per issue https://github.com/opentargets/platform/issues/799