### PR TITLE
Port Target Tractability to the new GraphQL API

### DIFF
--- a/src/public/configuration.js
+++ b/src/public/configuration.js
@@ -1,6 +1,6 @@
 export const targetSectionsDefaultOrder = [
   // 'drugs',
-  // 'tractability',
+  'tractability',
   // 'safety',
   'chemicalProbes',
   // 'bibliography',

--- a/src/public/target/sectionIndex.js
+++ b/src/public/target/sectionIndex.js
@@ -15,7 +15,7 @@ import * as chemicalProbesRaw from './sections/ChemicalProbes';
 // import * as proteinInteractionsRaw from './sections/ProteinInteractions';
 import * as relatedTargetsRaw from './sections/RelatedTargets';
 // import * as safetyRaw from './sections/Safety';
-// import * as tractabilityRaw from './sections/Tractability';
+import * as tractabilityRaw from './sections/Tractability';
 // import * as variationRaw from './sections/Variation';
 
 // export const bibliography = bibliographyRaw;
@@ -33,4 +33,4 @@ export const chemicalProbes = chemicalProbesRaw;
 export const relatedTargets = relatedTargetsRaw;
 // export const safety = safetyRaw;
 // export const variation = variationRaw;
-// export const tractability = tractabilityRaw;
+export const tractability = tractabilityRaw;

--- a/src/public/target/sections/Tractability/Section.js
+++ b/src/public/target/sections/Tractability/Section.js
@@ -1,9 +1,11 @@
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
-import withStyles from '@material-ui/core/styles/withStyles';
+import { makeStyles } from '@material-ui/core/styles';
+import _ from 'lodash';
 
-const styles = theme => ({
+// make a style hook to share between the components in this file
+const useStyles = makeStyles(theme => ({
   table: {
     borderCollapse: 'collapse',
     marginBottom: '8px',
@@ -18,10 +20,14 @@ const styles = theme => ({
     fontWeight: 'bold',
     color: 'white',
   },
-});
+}));
 
-const Section = ({ classes, ensgId, data }) => {
-  const { antibody, smallMolecule } = data;
+const Section = ({ data }) => {
+  const classes = useStyles();
+  const isSmallMoleculeCellPurple = bucket =>
+    _.get(data, 'smallmolecule.buckets', []).indexOf(bucket) >= 0;
+  const isAntibodyCellPurple = bucket =>
+    _.get(data, 'antibody.buckets', []).indexOf(bucket) >= 0;
   return (
     <Fragment>
       <Typography variant="h6">Small molecule</Typography>
@@ -41,20 +47,33 @@ const Section = ({ classes, ensgId, data }) => {
         </thead>
         <tbody>
           <tr>
-            {smallMolecule.map(m => {
-              return (
-                <td
-                  className={classNames(classes.cell, {
-                    [classes.purpleCell]: m.value,
-                  })}
-                  key={m.chemblBucket}
-                >
-                  <Typography color="inherit" variant="caption">
-                    {m.description}
-                  </Typography>
-                </td>
-              );
-            })}
+            {/* clinical precedence */}
+            <BucketCell isPurple={isSmallMoleculeCellPurple(1)}>
+              Phase 4
+            </BucketCell>
+            <BucketCell isPurple={isSmallMoleculeCellPurple(2)}>
+              Phase 2 or 3
+            </BucketCell>
+            <BucketCell isPurple={isSmallMoleculeCellPurple(3)}>
+              Phase 0 or 1
+            </BucketCell>
+            {/* discovery precedence */}
+            <BucketCell isPurple={isSmallMoleculeCellPurple(4)}>
+              PDB targets with ligands
+            </BucketCell>
+            <BucketCell isPurple={isSmallMoleculeCellPurple(7)}>
+              Active compounds in ChEMBL
+            </BucketCell>
+            {/* predicted tractable */}
+            <BucketCell isPurple={isSmallMoleculeCellPurple(5)}>
+              DrugEBIlity score > 0.7
+            </BucketCell>
+            <BucketCell isPurple={isSmallMoleculeCellPurple(6)}>
+              DrugEBIlity score 0 to 0.7
+            </BucketCell>
+            <BucketCell isPurple={isSmallMoleculeCellPurple(8)}>
+              Druggable genome
+            </BucketCell>
           </tr>
         </tbody>
       </table>
@@ -79,20 +98,35 @@ const Section = ({ classes, ensgId, data }) => {
         </thead>
         <tbody>
           <tr>
-            {antibody.map(ab => {
-              return (
-                <td
-                  className={classNames(classes.cell, {
-                    [classes.purpleCell]: ab.value,
-                  })}
-                  key={ab.chemblBucket}
-                >
-                  <Typography color="inherit" variant="caption">
-                    {ab.description}
-                  </Typography>
-                </td>
-              );
-            })}
+            {/* clinical precedence */}
+            <BucketCell isPurple={isAntibodyCellPurple(1)}>Phase 4</BucketCell>
+            <BucketCell isPurple={isAntibodyCellPurple(2)}>
+              Phase 2 or 3
+            </BucketCell>
+            <BucketCell isPurple={isAntibodyCellPurple(3)}>
+              Phase 0 or 1
+            </BucketCell>
+            {/* predicted tractable (high) */}
+            <BucketCell isPurple={isAntibodyCellPurple(4)}>
+              UniProt location - high confidence
+            </BucketCell>
+            <BucketCell isPurple={isAntibodyCellPurple(5)}>
+              GO cell component - high confidence
+            </BucketCell>
+            {/* predicted tractable (mid-low) */}
+            <BucketCell isPurple={isAntibodyCellPurple(6)}>
+              UniProt location - low or unknown confidence
+            </BucketCell>
+            <BucketCell isPurple={isAntibodyCellPurple(7)}>
+              UniProt predicted signal peptide or transmembrane region
+            </BucketCell>
+            <BucketCell isPurple={isAntibodyCellPurple(8)}>
+              GO cell component - medium confidence
+            </BucketCell>
+            {/* predicted tractable (HPA) */}
+            <BucketCell isPurple={isAntibodyCellPurple(9)}>
+              Human Protein Atlas - high confidence
+            </BucketCell>
           </tr>
         </tbody>
       </table>
@@ -100,4 +134,17 @@ const Section = ({ classes, ensgId, data }) => {
   );
 };
 
-export default withStyles(styles)(Section);
+const BucketCell = ({ isPurple, children }) => {
+  const classes = useStyles();
+  return (
+    <td
+      className={classNames(classes.cell, { [classes.purpleCell]: isPurple })}
+    >
+      <Typography color="inherit" variant="caption">
+        {children}
+      </Typography>
+    </td>
+  );
+};
+
+export default Section;

--- a/src/public/target/sections/Tractability/Summary.js
+++ b/src/public/target/sections/Tractability/Summary.js
@@ -1,14 +1,13 @@
-const Summary = ({
-  hasAntibodyTractabilityAssessment,
-  hasSmallMoleculeTractabilityAssessment,
-}) => {
-  const sources = ['antibody', 'small molecule'].filter(
-    (d, i) =>
-      [
-        hasAntibodyTractabilityAssessment,
-        hasSmallMoleculeTractabilityAssessment,
-      ][i]
-  );
+import _ from 'lodash';
+
+const Summary = ({ data }) => {
+  const sources = [];
+  if (_.get(data, 'antibody.buckets.length', 0) > 0) {
+    sources.push('antibody');
+  }
+  if (_.get(data, 'smallmolecule.buckets.length', 0) > 0) {
+    sources.push('small molecule');
+  }
   return sources.length > 0 ? sources.join(' • ') : null;
 };
 

--- a/src/public/target/sections/Tractability/index.js
+++ b/src/public/target/sections/Tractability/index.js
@@ -1,12 +1,13 @@
 import { loader } from 'graphql.macro';
+import _ from 'lodash';
 
 export const id = 'tractability';
 export const name = 'Tractability';
 export const shortName = 'TR';
 
 export const hasSummaryData = data =>
-  data.hasAntibodyTractabilityAssessment ||
-  data.hasSmallMoleculeTractabilityAssessment;
+  _.get(data, 'antibody.buckets.length', 0) > 0 ||
+  _.get(data, 'smallmolecule.buckets.length', 0) > 0;
 
 export const summaryQuery = loader('./summaryQuery.gql');
 export const sectionQuery = loader('./sectionQuery.gql');

--- a/src/public/target/sections/Tractability/sectionQuery.gql
+++ b/src/public/target/sections/Tractability/sectionQuery.gql
@@ -1,18 +1,12 @@
 query TargetTractabilitySectionQuery($ensgId: String!) {
-  target(ensgId: $ensgId) {
+  target(ensemblId: $ensgId) {
     id
-    details {
-      tractability {
-        smallMolecule {
-          chemblBucket
-          description
-          value
-        }
-        antibody {
-          chemblBucket
-          description
-          value
-        }
+    tractability {
+      smallmolecule {
+        buckets
+      }
+      antibody {
+        buckets
       }
     }
   }

--- a/src/public/target/sections/Tractability/summaryQuery.gql
+++ b/src/public/target/sections/Tractability/summaryQuery.gql
@@ -1,10 +1,10 @@
-fragment targetTractabilityFragment on TargetSummaries {
+fragment targetTractabilityFragment on Target {
   tractability {
-    hasSmallMoleculeTractabilityAssessment
-    hasAntibodyTractabilityAssessment
-    sources {
-      url
-      name
+    smallmolecule {
+      buckets
+    }
+    antibody {
+      buckets
     }
   }
 }


### PR DESCRIPTION
Re-enabling the Tractability section on the target page, by introducing an
ID-label mapping that was previously coded into the GraphQL backend.

![Screenshot of the summary widget for Tractability](https://user-images.githubusercontent.com/4929431/81561554-a2dba280-9393-11ea-9c3a-6346a48d8ddd.png)

![Screenshot of the Tractability section](https://user-images.githubusercontent.com/4929431/81561710-e46c4d80-9393-11ea-8222-f5499287e308.png)

