### PR TITLE
Port Target Safety to the GraphQL API

### DIFF
--- a/src/public/configuration.js
+++ b/src/public/configuration.js
@@ -1,7 +1,7 @@
 export const targetSectionsDefaultOrder = [
   // 'drugs',
   'tractability',
-  // 'safety',
+  'safety',
   'chemicalProbes',
   // 'bibliography',
   // 'variation',

--- a/src/public/target/sectionIndex.js
+++ b/src/public/target/sectionIndex.js
@@ -14,7 +14,7 @@ import * as geneOntologyRaw from './sections/GeneOntology';
 // import * as proteinRaw from './sections/ProteinInformation';
 // import * as proteinInteractionsRaw from './sections/ProteinInteractions';
 import * as relatedTargetsRaw from './sections/RelatedTargets';
-// import * as safetyRaw from './sections/Safety';
+import * as safetyRaw from './sections/Safety';
 import * as tractabilityRaw from './sections/Tractability';
 // import * as variationRaw from './sections/Variation';
 
@@ -31,6 +31,6 @@ export const geneOntology = geneOntologyRaw;
 // export const protein = proteinRaw;
 // export const proteinInteractions = proteinInteractionsRaw;
 export const relatedTargets = relatedTargetsRaw;
-// export const safety = safetyRaw;
+export const safety = safetyRaw;
 // export const variation = variationRaw;
 export const tractability = tractabilityRaw;

--- a/src/public/target/sections/Safety/Section.js
+++ b/src/public/target/sections/Safety/Section.js
@@ -1,84 +1,86 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+import _ from 'lodash';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 
 import { OtTableRF, Link, DataDownloader } from 'ot-ui';
 
+const Section = ({ symbol, data }) => {
+  const { adverseEffects, safetyRiskInfo } = data;
+  return (
+    <>
+      <Typography variant="h6">Known safety effects</Typography>
+      <DataDownloader
+        tableHeaders={effectsColumns}
+        rows={getAdverseDownloadData(adverseEffects)}
+        fileStem={`${symbol}-safety-effects`}
+      />
+      <OtTableRF columns={effectsColumns} data={adverseEffects} />
+      <Typography variant="h6">Safety risk information</Typography>
+      <DataDownloader
+        tableHeaders={riskColumns}
+        rows={getRiskDownloadData(safetyRiskInfo)}
+        fileStem={`${symbol}-risk-information`}
+      />
+      <OtTableRF columns={riskColumns} data={safetyRiskInfo} />
+    </>
+  );
+};
+
 const effectsColumns = [
   {
     id: 'organs_systems_affected',
     label: 'Main organs & systems affected',
-    renderCell: ({ organs_systems_affected: organs }) => {
-      return (
-        <ul>
-          {organs.map(organ => (
-            <li key={organ.code}>{organ.mapped_term}</li>
+    renderCell: ({ organsSystemsAffected }) => (
+      <ul>
+        {organsSystemsAffected
+          .filter(organ => organ.code && organ.mappedTerm)
+          .map(organ => (
+            <li key={organ.code}>{organ.mappedTerm}</li>
           ))}
-        </ul>
-      );
-    },
+      </ul>
+    ),
   },
   {
     id: 'activation_effects',
     label: 'Agonism or activation effects',
-    renderCell: ({ activation_effects: activationEffects }) => {
-      return Object.keys(activationEffects).map(key => {
-        return (
-          <React.Fragment key={key}>
-            <Typography variant="subtitle2">{capitalize(key)}</Typography>
-            <ul>
-              {activationEffects[key].map((effect, i) => (
-                <li key={i}>{effect.mapped_term || effect.term_in_paper}</li>
-              ))}
-            </ul>
-          </React.Fragment>
-        );
-      });
-    },
+    renderCell: ({ activationEffects }) =>
+      listTermsByGroup(activationEffects).map(({ groupKey, terms }) => (
+        <React.Fragment key={groupKey}>
+          <Typography variant="subtitle2">
+            {_.capitalize(_.lowerCase(groupKey))}
+          </Typography>
+          <ul>
+            {terms.map(term => (
+              <li key={`${groupKey}:${term}`}>{term}</li>
+            ))}
+          </ul>
+        </React.Fragment>
+      )),
   },
   {
     id: 'inhibition_effects',
     label: 'Antagonism or inhibition effects',
-    renderCell: ({ inhibition_effects: inhibitionEffects }) => {
-      return Object.keys(inhibitionEffects).map(key => {
-        return (
-          <React.Fragment key={key}>
-            <Typography variant="subtitle2">{capitalize(key)}</Typography>
-            <ul>
-              {inhibitionEffects[key].map((effect, i) => (
-                <li key={i}>{effect.mapped_term || effect.term_in_paper}</li>
-              ))}
-            </ul>
-          </React.Fragment>
-        );
-      });
-    },
+    renderCell: ({ inhibitionEffects }) =>
+      listTermsByGroup(inhibitionEffects).map(({ groupKey, terms }) => (
+        <React.Fragment key={groupKey}>
+          <Typography variant="subtitle2">
+            {_.capitalize(_.lowerCase(groupKey))}
+          </Typography>
+          <ul>
+            {terms.map(term => (
+              <li key={`${groupKey}:${term}`}>{term}</li>
+            ))}
+          </ul>
+        </React.Fragment>
+      )),
   },
   {
     id: 'references',
     label: 'Publications',
-    renderCell: ({ references }) => {
-      return references.map((reference, i) => {
-        const isHecatos = reference.ref_link.indexOf('hecatos') !== -1;
-        return (
-          <React.Fragment key={i}>
-            <Link external to={reference.ref_link}>
-              <Tooltip
-                title={
-                  isHecatos
-                    ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156).'"
-                    : ''
-                }
-                placement="top"
-              >
-                <span>{reference.ref_label}</span>
-              </Tooltip>
-            </Link>{' '}
-          </React.Fragment>
-        );
-      });
-    },
+    renderCell: ({ references }) => (
+      <ReferencesCell>{references}</ReferencesCell>
+    ),
   },
 ];
 
@@ -86,136 +88,111 @@ const riskColumns = [
   {
     id: 'organs_systems_affected',
     label: 'Main organs & systems affected',
-    renderCell: ({ organs_systems_affected: organs }) => {
-      return (
-        <ul>
-          {organs.map((organ, i) => (
-            <li key={i}>{organ.mapped_term || organ.term_in_paper}</li>
+    renderCell: ({ organsSystemsAffected }) => (
+      <ul>
+        {organsSystemsAffected
+          .filter(
+            organ => organ.code && (organ.mappedTerm || organ.termInPaper)
+          )
+          .map(organ => (
+            <li key={organ.code}>{organ.mappedTerm || organ.termInPaper}</li>
           ))}
-        </ul>
-      );
-    },
+      </ul>
+    ),
   },
   {
     id: 'safety_liability',
     label: 'Safety liability information',
-    renderCell: ({ safety_liability }) => {
-      return safety_liability;
-    },
+    renderCell: ({ safetyLiability }) => safetyLiability,
   },
   {
     id: 'references',
     label: 'Publications',
-    renderCell: ({ references }) => {
-      return references.map((reference, i) => {
-        const isHecatos = reference.ref_link.indexOf('hecatos') !== -1;
-        return (
-          <React.Fragment key={i}>
-            <Link external to={reference.ref_link}>
-              <Tooltip
-                title={
-                  isHecatos
-                    ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156).'"
-                    : ''
-                }
-                placement="top"
-              >
-                <span>{reference.ref_label}</span>
-              </Tooltip>
-            </Link>{' '}
-          </React.Fragment>
-        );
-      });
-    },
+    renderCell: ({ references }) => (
+      <ReferencesCell>{references}</ReferencesCell>
+    ),
   },
 ];
 
+const ReferencesCell = ({ children }) =>
+  children
+    .filter(reference => reference.pubmedId || reference.refLink)
+    .map(({ pubmedId, refLink, refLabel }) => {
+      const pubUrl = pubmedId
+        ? 'https://europepmc.org/abstract/MED/' + pubmedId
+        : refLink;
+      const isHecatos = refLink && refLink.indexOf('hecatos') !== -1;
+      return (
+        <React.Fragment key={`${refLabel}:${pubUrl}`}>
+          <Link external to={pubUrl}>
+            <Tooltip
+              title={
+                isHecatos
+                  ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156).'"
+                  : ''
+              }
+              placement="top"
+            >
+              <span>
+                {refLabel ||
+                  (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
+              </span>
+            </Tooltip>
+          </Link>{' '}
+        </React.Fragment>
+      );
+    });
+
 const getAdverseDownloadData = rows => {
-  return rows.map(row => {
-    const activationEffects = [];
-    const inhibitionEffects = [];
+  const flattenEffects = subGraph =>
+    _.flatMap(listTermsByGroup(subGraph), ({ terms }) => terms);
 
-    Object.keys(row.activation_effects).forEach(key => {
-      row.activation_effects[key].forEach(effect => {
-        activationEffects.push(effect.mapped_term || effect.term_in_paper);
-      });
-    });
-
-    Object.keys(row.inhibition_effects).forEach(key => {
-      row.inhibition_effects[key].forEach(effect => {
-        inhibitionEffects.push(effect.mapped_term || effect.term_in_paper);
-      });
-    });
-
-    return {
-      organs_systems_affected: row.organs_systems_affected
-        .map(organ => organ.mapped_term)
-        .join(', '),
-      activation_effects: activationEffects.join(', '),
-      inhibition_effects: inhibitionEffects.join(', '),
-      references: row.references.map(ref => ref.ref_link).join(', '),
-    };
-  });
+  return rows.map(row => ({
+    organs_systems_affected: row.organsSystemsAffected
+      .map(organ => organ.mappedTerm)
+      .filter(term => term)
+      .join(', '),
+    activation_effects: flattenEffects(row.activationEffects).join(', '),
+    inhibition_effects: flattenEffects(row.inhibitionEffects).join(', '),
+    references: row.references
+      .map(ref =>
+        ref.pubmedId
+          ? 'https://europepmc.org/abstract/MED/' + ref.pubmedId
+          : ref.refLink
+      )
+      .filter(link => link)
+      .join(', '),
+  }));
 };
 
 const getRiskDownloadData = rows => {
-  return rows.map(row => {
-    return {
-      organs_systems_affected: row.organs_systems_affected
-        .map(organ => organ.mapped_term || organ.term_in_paper)
-        .join(', '),
-      safety_liability: row.safety_liability,
-      references: row.references.map(ref => ref.ref_link).join(', '),
-    };
-  });
+  return rows.map(row => ({
+    organs_systems_affected: row.organsSystemsAffected
+      .map(organ => organ.mappedTerm || organ.termInPaper)
+      .filter(term => term)
+      .join(', '),
+    safety_liability: row.safetyLiability,
+    references: row.references
+      .map(ref =>
+        ref.pubmedId
+          ? 'https://europepmc.org/abstract/MED/' + ref.pubmedId
+          : ref.refLink
+      )
+      .filter(link => link)
+      .join(', '),
+  }));
 };
 
-class Section extends React.Component {
-  state = { loading: true };
-
-  componentDidMount() {
-    // TODO: safety data should be loaded through graphql api
-    fetch(
-      `https://platform-api-qc.opentargets.io/v3/platform/private/target/${this.props.ensgId}`
-    )
-      .then(res => res.json())
-      .then(data => {
-        this.setState({ loading: false, safety: data.safety });
-      });
-  }
-
-  render() {
-    const { symbol } = this.props;
-    const { loading, safety } = this.state;
-
-    if (!safety) {
-      return null;
-    }
-
-    const {
-      adverse_effects: adverseEffects = [],
-      safety_risk_info: safetyRiskInfo = [],
-    } = safety;
-
-    return !loading ? (
-      <React.Fragment>
-        <Typography variant="h6">Known safety effects</Typography>
-        <DataDownloader
-          tableHeaders={effectsColumns}
-          rows={getAdverseDownloadData(adverseEffects)}
-          fileStem={`${symbol}-safety-effects`}
-        />
-        <OtTableRF columns={effectsColumns} data={adverseEffects} />
-        <Typography variant="h6">Safety risk information</Typography>
-        <DataDownloader
-          tableHeaders={riskColumns}
-          rows={getRiskDownloadData(safetyRiskInfo)}
-          fileStem={`${symbol}-risk-information`}
-        />
-        <OtTableRF columns={riskColumns} data={safetyRiskInfo} />
-      </React.Fragment>
-    ) : null;
-  }
-}
+const listTermsByGroup = effectsSubGraph =>
+  Object.entries(effectsSubGraph)
+    // exclude GraphQL introspection properties
+    .filter(([key, __]) => !key.startsWith('__'))
+    .map(([groupKey, effects]) => ({
+      groupKey,
+      terms: effects
+        .map(effect => effect.mappedTerm || effect.termInPaper)
+        .filter(term => term),
+    }))
+    .filter(({ terms }) => terms.length);
 
 export default Section;

--- a/src/public/target/sections/Safety/Section.js
+++ b/src/public/target/sections/Safety/Section.js
@@ -1,186 +1,28 @@
 import React from 'react';
-import _ from 'lodash';
-import Typography from '@material-ui/core/Typography';
-import Tooltip from '@material-ui/core/Tooltip';
 
-import { OtTableRF, Link, DataDownloader } from 'ot-ui';
+import SafetyTables from './custom/SafetyTables';
 
 const Section = ({ symbol, data }) => {
-  const { adverseEffects, safetyRiskInfo } = data;
   return (
-    <>
-      <Typography variant="h6">Known safety effects</Typography>
-      <DataDownloader
-        tableHeaders={effectsColumns}
-        rows={getAdverseDownloadData(adverseEffects)}
-        fileStem={`${symbol}-safety-effects`}
-      />
-      <OtTableRF columns={effectsColumns} data={adverseEffects} />
-      <Typography variant="h6">Safety risk information</Typography>
-      <DataDownloader
-        tableHeaders={riskColumns}
-        rows={getRiskDownloadData(safetyRiskInfo)}
-        fileStem={`${symbol}-risk-information`}
-      />
-      <OtTableRF columns={riskColumns} data={safetyRiskInfo} />
-    </>
+    <SafetyTables
+      symbol={symbol}
+      data={{
+        adverseEffects: data.adverseEffects.map(row => ({
+          organsSystemsAffected: row.organsSystemsAffected
+            .map(organ => ({ ...organ, preferredTerm: organ.mappedTerm }))
+            .filter(organ => organ.preferredTerm),
+          activationEffects: listTermsByGroup(row.activationEffects),
+          inhibitionEffects: listTermsByGroup(row.inhibitionEffects),
+          references: addPubUrl(row.references),
+        })),
+        safetyRiskInfo: data.safetyRiskInfo.map(row => ({
+          ...row,
+          organsSystemsAffected: addPreferredTerm(row.organsSystemsAffected),
+          references: addPubUrl(row.references),
+        })),
+      }}
+    />
   );
-};
-
-const effectsColumns = [
-  {
-    id: 'organs_systems_affected',
-    label: 'Main organs & systems affected',
-    renderCell: ({ organsSystemsAffected }) => (
-      <ul>
-        {organsSystemsAffected
-          .filter(organ => organ.code && organ.mappedTerm)
-          .map(organ => (
-            <li key={organ.code}>{organ.mappedTerm}</li>
-          ))}
-      </ul>
-    ),
-  },
-  {
-    id: 'activation_effects',
-    label: 'Agonism or activation effects',
-    renderCell: ({ activationEffects }) =>
-      listTermsByGroup(activationEffects).map(({ groupKey, terms }) => (
-        <React.Fragment key={groupKey}>
-          <Typography variant="subtitle2">
-            {_.capitalize(_.lowerCase(groupKey))}
-          </Typography>
-          <ul>
-            {terms.map(term => (
-              <li key={`${groupKey}:${term}`}>{term}</li>
-            ))}
-          </ul>
-        </React.Fragment>
-      )),
-  },
-  {
-    id: 'inhibition_effects',
-    label: 'Antagonism or inhibition effects',
-    renderCell: ({ inhibitionEffects }) =>
-      listTermsByGroup(inhibitionEffects).map(({ groupKey, terms }) => (
-        <React.Fragment key={groupKey}>
-          <Typography variant="subtitle2">
-            {_.capitalize(_.lowerCase(groupKey))}
-          </Typography>
-          <ul>
-            {terms.map(term => (
-              <li key={`${groupKey}:${term}`}>{term}</li>
-            ))}
-          </ul>
-        </React.Fragment>
-      )),
-  },
-  {
-    id: 'references',
-    label: 'Publications',
-    renderCell: ({ references }) => (
-      <ReferencesCell>{references}</ReferencesCell>
-    ),
-  },
-];
-
-const riskColumns = [
-  {
-    id: 'organs_systems_affected',
-    label: 'Main organs & systems affected',
-    renderCell: ({ organsSystemsAffected }) => (
-      <ul>
-        {organsSystemsAffected
-          .filter(
-            organ => organ.code && (organ.mappedTerm || organ.termInPaper)
-          )
-          .map(organ => (
-            <li key={organ.code}>{organ.mappedTerm || organ.termInPaper}</li>
-          ))}
-      </ul>
-    ),
-  },
-  {
-    id: 'safety_liability',
-    label: 'Safety liability information',
-    renderCell: ({ safetyLiability }) => safetyLiability,
-  },
-  {
-    id: 'references',
-    label: 'Publications',
-    renderCell: ({ references }) => (
-      <ReferencesCell>{references}</ReferencesCell>
-    ),
-  },
-];
-
-const ReferencesCell = ({ children }) =>
-  children
-    .filter(reference => reference.pubmedId || reference.refLink)
-    .map(({ pubmedId, refLink, refLabel }) => {
-      const pubUrl = pubmedId
-        ? 'https://europepmc.org/abstract/MED/' + pubmedId
-        : refLink;
-      const isHecatos = refLink && refLink.indexOf('hecatos') !== -1;
-      return (
-        <React.Fragment key={`${refLabel}:${pubUrl}`}>
-          <Link external to={pubUrl}>
-            <Tooltip
-              title={
-                isHecatos
-                  ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156).'"
-                  : ''
-              }
-              placement="top"
-            >
-              <span>
-                {refLabel ||
-                  (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
-              </span>
-            </Tooltip>
-          </Link>{' '}
-        </React.Fragment>
-      );
-    });
-
-const getAdverseDownloadData = rows => {
-  const flattenEffects = subGraph =>
-    _.flatMap(listTermsByGroup(subGraph), ({ terms }) => terms);
-
-  return rows.map(row => ({
-    organs_systems_affected: row.organsSystemsAffected
-      .map(organ => organ.mappedTerm)
-      .filter(term => term)
-      .join(', '),
-    activation_effects: flattenEffects(row.activationEffects).join(', '),
-    inhibition_effects: flattenEffects(row.inhibitionEffects).join(', '),
-    references: row.references
-      .map(ref =>
-        ref.pubmedId
-          ? 'https://europepmc.org/abstract/MED/' + ref.pubmedId
-          : ref.refLink
-      )
-      .filter(link => link)
-      .join(', '),
-  }));
-};
-
-const getRiskDownloadData = rows => {
-  return rows.map(row => ({
-    organs_systems_affected: row.organsSystemsAffected
-      .map(organ => organ.mappedTerm || organ.termInPaper)
-      .filter(term => term)
-      .join(', '),
-    safety_liability: row.safetyLiability,
-    references: row.references
-      .map(ref =>
-        ref.pubmedId
-          ? 'https://europepmc.org/abstract/MED/' + ref.pubmedId
-          : ref.refLink
-      )
-      .filter(link => link)
-      .join(', '),
-  }));
 };
 
 const listTermsByGroup = effectsSubGraph =>
@@ -189,10 +31,26 @@ const listTermsByGroup = effectsSubGraph =>
     .filter(([key, __]) => !key.startsWith('__'))
     .map(([groupKey, effects]) => ({
       groupKey,
-      terms: effects
-        .map(effect => effect.mappedTerm || effect.termInPaper)
-        .filter(term => term),
+      terms: addPreferredTerm(effects).map(effect => effect.preferredTerm),
     }))
-    .filter(({ terms }) => terms.length);
+    .filter(group => group.terms.length);
+
+const addPreferredTerm = section =>
+  section
+    .map(organ => ({
+      ...organ,
+      preferredTerm: organ.mappedTerm || organ.termInPaper,
+    }))
+    .filter(organ => organ.preferredTerm);
+
+const addPubUrl = referencesSection =>
+  referencesSection
+    .map(ref => ({
+      ...ref,
+      pubUrl: ref.pubmedId
+        ? 'https://europepmc.org/abstract/MED/' + ref.pubmedId
+        : ref.refLink,
+    }))
+    .filter(ref => ref.pubUrl);
 
 export default Section;

--- a/src/public/target/sections/Safety/Summary.js
+++ b/src/public/target/sections/Safety/Summary.js
@@ -1,27 +1,3 @@
-import React from 'react';
-
-class Summary extends React.Component {
-  state = { safety: null };
-  componentDidMount() {
-    const { ensgId, setHasSummaryData, setHasSummaryError } = this.props;
-    fetch(
-      `https://platform-api-qc.opentargets.io/v3/platform/private/target/${ensgId}`
-    )
-      .then(res => res.json())
-      .then(data => {
-        this.setState({ safety: data.safety });
-        setHasSummaryData(data.safety);
-      })
-
-      .catch(error => {
-        setHasSummaryError(true);
-      });
-  }
-  render() {
-    const { safety } = this.state;
-
-    return safety ? 'available' : '(no data)';
-  }
-}
+const Summary = () => 'available';
 
 export default Summary;

--- a/src/public/target/sections/Safety/custom/SafetyTables.js
+++ b/src/public/target/sections/Safety/custom/SafetyTables.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import _ from 'lodash';
+import Typography from '@material-ui/core/Typography';
+import Tooltip from '@material-ui/core/Tooltip';
+
+import { OtTableRF, Link, DataDownloader } from 'ot-ui';
+
+const SafetyTables = ({ symbol, data }) => {
+  const { adverseEffects, safetyRiskInfo } = data;
+  return (
+    <>
+      <Typography variant="h6">Known safety effects</Typography>
+      <DataDownloader
+        tableHeaders={effectsColumns}
+        rows={getAdverseDownloadData(adverseEffects)}
+        fileStem={`${symbol}-safety-effects`}
+      />
+      <OtTableRF columns={effectsColumns} data={adverseEffects} />
+      <Typography variant="h6">Safety risk information</Typography>
+      <DataDownloader
+        tableHeaders={riskColumns}
+        rows={getRiskDownloadData(safetyRiskInfo)}
+        fileStem={`${symbol}-risk-information`}
+      />
+      <OtTableRF columns={riskColumns} data={safetyRiskInfo} />
+    </>
+  );
+};
+
+const effectsColumns = [
+  {
+    id: 'organs_systems_affected',
+    label: 'Main organs & systems affected',
+    renderCell: ({ organsSystemsAffected }) => (
+      <ul>
+        {organsSystemsAffected
+          .filter(organ => organ.code)
+          .map(organ => (
+            <li key={organ.code}>{organ.mappedTerm}</li>
+          ))}
+      </ul>
+    ),
+  },
+  {
+    id: 'activation_effects',
+    label: 'Agonism or activation effects',
+    renderCell: ({ activationEffects }) =>
+      activationEffects.map(({ groupKey, terms }) => (
+        <React.Fragment key={groupKey}>
+          <Typography variant="subtitle2">
+            {_.capitalize(_.lowerCase(groupKey))}
+          </Typography>
+          <ul>
+            {terms.map(term => (
+              <li key={`${groupKey}:${term}`}>{term}</li>
+            ))}
+          </ul>
+        </React.Fragment>
+      )),
+  },
+  {
+    id: 'inhibition_effects',
+    label: 'Antagonism or inhibition effects',
+    renderCell: ({ inhibitionEffects }) =>
+      inhibitionEffects.map(({ groupKey, terms }) => (
+        <React.Fragment key={groupKey}>
+          <Typography variant="subtitle2">
+            {_.capitalize(_.lowerCase(groupKey))}
+          </Typography>
+          <ul>
+            {terms.map(term => (
+              <li key={`${groupKey}:${term}`}>{term}</li>
+            ))}
+          </ul>
+        </React.Fragment>
+      )),
+  },
+  {
+    id: 'references',
+    label: 'Publications',
+    renderCell: ({ references }) => (
+      <ReferencesCell>{references}</ReferencesCell>
+    ),
+  },
+];
+
+const riskColumns = [
+  {
+    id: 'organs_systems_affected',
+    label: 'Main organs & systems affected',
+    renderCell: ({ organsSystemsAffected }) => (
+      <ul>
+        {organsSystemsAffected
+          .filter(organ => organ.code)
+          .map(organ => (
+            <li key={organ.code}>{organ.preferredTerm}</li>
+          ))}
+      </ul>
+    ),
+  },
+  {
+    id: 'safety_liability',
+    label: 'Safety liability information',
+    renderCell: ({ safetyLiability }) => safetyLiability,
+  },
+  {
+    id: 'references',
+    label: 'Publications',
+    renderCell: ({ references }) => (
+      <ReferencesCell>{references}</ReferencesCell>
+    ),
+  },
+];
+
+const ReferencesCell = ({ children }) =>
+  children
+    .filter(reference => reference.pubmedId || reference.refLink)
+    .map(({ pubUrl, refLabel, pubmedId }) => {
+      const isHecatos = pubUrl.indexOf('hecatos') !== -1;
+      return (
+        <React.Fragment key={`${refLabel}:${pubUrl}`}>
+          <Link external to={pubUrl}>
+            <Tooltip
+              title={
+                isHecatos
+                  ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156).'"
+                  : ''
+              }
+              placement="top"
+            >
+              <span>
+                {refLabel ||
+                  (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
+              </span>
+            </Tooltip>
+          </Link>{' '}
+        </React.Fragment>
+      );
+    });
+
+const getAdverseDownloadData = rows => {
+  const flattenEffects = subGraph => _.flatMap(subGraph, ({ terms }) => terms);
+
+  return rows.map(row => ({
+    organs_systems_affected: row.organsSystemsAffected
+      .map(organ => organ.preferredTerm)
+      .join(', '),
+    activation_effects: flattenEffects(row.activationEffects).join(', '),
+    inhibition_effects: flattenEffects(row.inhibitionEffects).join(', '),
+    references: row.references.map(ref => ref.pubUrl).join(', '),
+  }));
+};
+
+const getRiskDownloadData = rows => {
+  return rows.map(row => ({
+    organs_systems_affected: row.organsSystemsAffected
+      .map(organ => organ.preferredTerm)
+      .join(', '),
+    safety_liability: row.safetyLiability,
+    references: row.references.map(ref => ref.pubUrl).join(', '),
+  }));
+};
+
+export default SafetyTables;

--- a/src/public/target/sections/Safety/index.js
+++ b/src/public/target/sections/Safety/index.js
@@ -1,5 +1,22 @@
+import { loader } from 'graphql.macro';
+import gql from 'graphql-tag';
+
 export const id = 'safety';
 export const name = 'Safety';
+
+export const hasSummaryData = data => data;
+
+export const summaryQuery = loader('./summaryQuery.gql');
+export const sectionQuery = gql`
+  query TargetSafetySectionQuery($ensgId: String!) {
+    target(ensemblId: $ensgId) {
+      id
+      ...targetSafetyFragment
+    }
+  }
+
+  ${summaryQuery}
+`;
 
 export { default as DescriptionComponent } from './Description';
 export { default as SummaryComponent } from './Summary';

--- a/src/public/target/sections/Safety/summaryQuery.gql
+++ b/src/public/target/sections/Safety/summaryQuery.gql
@@ -1,0 +1,58 @@
+fragment targetSafetyFragment on Target {
+  # fetch the data the section needs, in order to see its availability
+  safety {
+    adverseEffects {
+      organsSystemsAffected {
+        code
+        mappedTerm
+      }
+      activationEffects {
+        acuteDosing {
+          ...termOptions
+        }
+        chronicDosing {
+          ...termOptions
+        }
+        general {
+          ...termOptions
+        }
+      }
+      inhibitionEffects {
+        acuteDosing {
+          ...termOptions
+        }
+        chronicDosing {
+          ...termOptions
+        }
+        general {
+          ...termOptions
+        }
+        developmental {
+          ...termOptions
+        }
+      }
+      references {
+        pubmedId
+        refLink
+        refLabel
+      }
+    }
+    safetyRiskInfo {
+      organsSystemsAffected {
+        code
+        ...termOptions
+      }
+      safetyLiability
+      references {
+        pubmedId
+        refLink
+        refLabel
+      }
+    }
+  }
+}
+
+fragment termOptions on SafetyCode {
+  mappedTerm
+  termInPaper
+}


### PR DESCRIPTION
Re-enabling the Safety section on the target page.

In the process, port the logic to format links based on Pubmed IDs from
the Angular webapp and make some of the list item keys passed to React
more robust (with the assumption that the same effect or publication
will not appear in the same row twice).

![Screenshot of the summary widget for the Safety section](https://user-images.githubusercontent.com/4929431/82078160-fa09ac00-96e0-11ea-8296-74d41eb51471.png)

![Screenshot of the Safety section](https://user-images.githubusercontent.com/4929431/82078398-608eca00-96e1-11ea-9f39-465e16cf09bb.png)
