### PR TITLE
Lf target variation

### DIFF
--- a/src/public/configuration.js
+++ b/src/public/configuration.js
@@ -4,7 +4,7 @@ export const targetSectionsDefaultOrder = [
   'safety',
   'chemicalProbes',
   'bibliography',
-  // 'variation',
+  'variation',
   // 'expression',
   // 'protein',
   // 'homology',

--- a/src/public/target/sectionIndex.js
+++ b/src/public/target/sectionIndex.js
@@ -16,7 +16,7 @@ import * as geneOntologyRaw from './sections/GeneOntology';
 import * as relatedTargetsRaw from './sections/RelatedTargets';
 import * as safetyRaw from './sections/Safety';
 import * as tractabilityRaw from './sections/Tractability';
-// import * as variationRaw from './sections/Variation';
+import * as variationRaw from './sections/Variation';
 
 export const bibliography = bibliographyRaw;
 export const cancerBiomarkers = cancerBiomarkersRaw;
@@ -32,5 +32,5 @@ export const geneOntology = geneOntologyRaw;
 // export const proteinInteractions = proteinInteractionsRaw;
 export const relatedTargets = relatedTargetsRaw;
 export const safety = safetyRaw;
-// export const variation = variationRaw;
+export const variation = variationRaw;
 export const tractability = tractabilityRaw;

--- a/src/public/target/sections/Variation/Summary.js
+++ b/src/public/target/sections/Variation/Summary.js
@@ -1,11 +1,5 @@
 import React from 'react';
 
-const Summary = ({ common, rare }) => (
-  <React.Fragment>
-    {`${common.variantsCount} variants (common diseases)`}
-    <br />
-    {`${rare.mutationsCount} mutations (rare diseases)`}
-  </React.Fragment>
-);
+const Summary = () => <>Available</>;
 
 export default Summary;

--- a/src/public/target/sections/Variation/index.js
+++ b/src/public/target/sections/Variation/index.js
@@ -4,10 +4,12 @@ export const id = 'variation';
 export const name = 'Variation and Genomic Context';
 export const shortName = 'V';
 
-export const hasSummaryData = ({ common, rare }) =>
-  common.variantsCount > 0 || rare.mutationsCount > 0;
+export const hasSummaryData = () => true;
 
-export const summaryQuery = loader('./summaryQuery.gql');
+// Disable summary query for now:
+// this widget will be enabled for every target.
+// If needed we could use genomicLocation to get a summary in the future
+// export const summaryQuery = loader('./summaryQuery.gql');
 
 export { default as DescriptionComponent } from './Description';
 export { default as SummaryComponent } from './Summary';


### PR DESCRIPTION
Short PR for the variation widget.

*Summary*
Currently there isn't a specific summary query in the API:
the widget will be enabled for all targets, so `hasSummaryData()` always evaluates to true. 
Possibly we could use the `genomicLocation` query endpoint in the future.

*Details*
The details/section pull directly from the opentargets and ensembl APIs so no changes there.

This fixes issue https://github.com/opentargets/platform/issues/1023
