### PR TITLE
Fix a console warning about unique fragment names

### DIFF
--- a/src/public/target/sections/Safety/index.js
+++ b/src/public/target/sections/Safety/index.js
@@ -1,5 +1,4 @@
-import { loader } from 'graphql.macro';
-import gql from 'graphql-tag';
+import { loader, gql } from 'graphql.macro';
 
 export const id = 'safety';
 export const name = 'Safety';


### PR DESCRIPTION
In commit bcd8b4b1e3401a7f7d8b9bd431b5ac3aa186c27c (pull request #146),
I made the Apollo GraphQL client output a warning to the browser console
on target page load:

> Warning: fragment with name targetSafetyFragment already
> exists. graphql-tag enforces all fragment names across your
> application to be unique; read more about this in the docs:
> http://dev.apollodata.com/core/fragments.html#unique-names

I believe that this happened because I defined the GraphQL fragment in a
file parsed by the loader() function from 'graphql.macro' at build-time,
but also inserted it into a gql template literal parsed by the
'graphql-tag' package. The 'graphql.macro' package provides its own gql
tag function, and using it seems to remove the warning.