### PR TITLE
Refiner.io survey tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -63,5 +63,14 @@
       async
       src="https://www.reactome.org/DiagramJs/diagram/diagram.nocache.js"
     ></script>
+    <script async src="https://js.refiner.io/v001/client.js"></script>
+    <!-- refiner.io survey tracking -->
+    <script>
+      window._refinerQueue = window._refinerQueue || [];
+      function _refiner() {
+        _refinerQueue.push(arguments);
+      }
+      _refiner('setProject', 'ade7da40-a960-11ea-9bbb-37035544d167');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds [refiner.io](https://refiner.io/) surveys to the alpha build. (opentargets/platform#1093)

They are added into the index.html template as the survey will be temporary at the start of the alpha and then removed from the platform.