### PR TITLE
Drug Profile Page fixes and enhancements

### DIFF
--- a/src/public/disease/sections/KnownDrugs/Section.js
+++ b/src/public/disease/sections/KnownDrugs/Section.js
@@ -6,7 +6,6 @@ import { Link } from 'ot-ui';
 import SourceDrawer from '../../../common/sections/KnownDrugs/custom/SourceDrawer';
 import Table from '../../../common/Table/Table';
 import useCursorBatchDownloader from '../../../../hooks/useCursorBatchDownloader';
-import useUpdateEffect from '../../../../hooks/useUpdateEffect';
 import { label } from '../../../../utils/global';
 import { sectionQuery } from '.';
 

--- a/src/public/drug/sections/KnownDrugs/Description.js
+++ b/src/public/drug/sections/KnownDrugs/Description.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import { Link } from 'ot-ui';
 
 const Description = ({ name }) => (
   <React.Fragment>
-    Drugs in clinical trials or approved for <strong>{name}</strong>.
+    Clinical trial records, including curated indication and mechanism of
+    action, for <strong>{name}</strong>. Source:{' '}
+    <Link external to="https://www.ebi.ac.uk/chembl/">
+      ChEMBL
+    </Link>
+    .
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/KnownDrugs/index.js
+++ b/src/public/drug/sections/KnownDrugs/index.js
@@ -1,7 +1,7 @@
 import { loader } from 'graphql.macro';
 
 export const id = 'knownDrugs';
-export const name = 'Known Drugs';
+export const name = 'Clinical Precedence';
 
 export const hasSummaryData = data => data && data.count > 0;
 


### PR DESCRIPTION
This PR addresses:

* Update Known Drugs summary widget and detail view on drug profile page (opentargets/platform#1100)

Also:

Removed an unused dependency from the Disease Profile Page Known Drugs widget.