### PR TITLE
Lf fix 1112

### DIFF
--- a/src/public/disease/sections/KnownDrugs/Summary.js
+++ b/src/public/disease/sections/KnownDrugs/Summary.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const Summary = ({ data }) => (
   <React.Fragment>
-    {(data.uniqueDrugs || 0).toLocaleString()} drugs in clinical trials
+    {(data.uniqueDrugs || 0).toLocaleString()} drugs witn{' '}
+    {(data.uniqueTargets || 0).toLocaleString()} targets
   </React.Fragment>
 );
 

--- a/src/public/disease/sections/KnownDrugs/summaryQuery.gql
+++ b/src/public/disease/sections/KnownDrugs/summaryQuery.gql
@@ -2,5 +2,6 @@ fragment diseaseKnownDrugsFragment on Disease {
   knownDrugs {
     count
     uniqueDrugs
+    uniqueTargets
   }
 }

--- a/src/public/drug/sections/KnownDrugs/Summary.js
+++ b/src/public/drug/sections/KnownDrugs/Summary.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const Summary = ({ data }) => (
   <React.Fragment>
-    {(data.count || 0).toLocaleString()} clinical trial records
+    {(data.uniqueTargets || 0).toLocaleString()} targets and{' '}
+    {(data.uniqueDiseases || 0).toLocaleString()} indications
   </React.Fragment>
 );
 

--- a/src/public/drug/sections/KnownDrugs/summaryQuery.gql
+++ b/src/public/drug/sections/KnownDrugs/summaryQuery.gql
@@ -1,5 +1,7 @@
 fragment drugKnownDrugsFragment on Drug {
   knownDrugs {
     count
+    uniqueTargets
+    uniqueDiseases
   }
 }

--- a/src/public/target/sections/KnownDrugs/Summary.js
+++ b/src/public/target/sections/KnownDrugs/Summary.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const Summary = ({ data }) => (
   <React.Fragment>
-    {data.uniqueDrugs || 0} drugs in clinical trials
+    {(data.uniqueDrugs || 0).toLocaleString()} drugs with{' '}
+    {(data.uniqueDiseases || 0).toLocaleString()} indications
   </React.Fragment>
 );
 

--- a/src/public/target/sections/KnownDrugs/summaryQuery.gql
+++ b/src/public/target/sections/KnownDrugs/summaryQuery.gql
@@ -2,5 +2,6 @@ fragment targetKnownDrugsFragment on Target {
   knownDrugs {
     count
     uniqueDrugs
+    uniqueDiseases
   }
 }

--- a/src/public/target/sections/Safety/Summary.js
+++ b/src/public/target/sections/Safety/Summary.js
@@ -1,3 +1,22 @@
-const Summary = () => 'available';
+const Summary = ({ data }) => {
+  const safetyDataTypes = [
+    {
+      id: 'adverseEffects',
+      label: 'Known effects',
+    },
+    {
+      id: 'safetyRiskInfo',
+      label: 'Risk info',
+    },
+    {
+      id: 'experimentalToxicity',
+      label: 'Non-clinical toxicity',
+    },
+  ];
+  return safetyDataTypes
+    .filter(d => data[d.id].length > 0)
+    .map(d => d.label)
+    .join(' • ');
+};
 
 export default Summary;


### PR DESCRIPTION
This PR updates the summary text for these widgets:

 - *Safety* on target profile page; closes https://github.com/opentargets/platform/issues/1112

 - *Known drugs* on target and disease profile page and *clinical precedence* on drugs profile page; relevant queries also updated; closes https://github.com/opentargets/platform/issues/1113
