### PR TITLE
Fix search page (opentargets/platform#1118)

### DIFF
--- a/src/public/search/DiseaseDetail.js
+++ b/src/public/search/DiseaseDetail.js
@@ -19,13 +19,7 @@ const styles = () => ({
 });
 
 const DiseaseDetail = ({ classes, data }) => {
-  const {
-    id,
-    name,
-    description,
-    associationsOnTheFly: { rows },
-    therapeuticAreas,
-  } = data;
+  const { id, name, description, therapeuticAreas } = data;
   return (
     <CardContent>
       <Typography color="primary" variant="h5">
@@ -35,19 +29,6 @@ const DiseaseDetail = ({ classes, data }) => {
         <DiseaseIcon className={classes.icon} /> Disease or phenotype
       </Typography>
       <LongText lineLimit={4}>{description}</LongText>
-      {/* temporarily hide top associated targets */}
-      {/* rows.length > 0 */ false && (
-        <>
-          <Typography className={classes.subtitle} variant="subtitle1">
-            Top associated targets
-          </Typography>
-          {rows.map(({ id }) => (
-            <Link key={id} to={`/target/${id}`}>
-              {id}
-            </Link>
-          ))}
-        </>
-      )}
       {therapeuticAreas.length > 0 && (
         <>
           <Typography className={classes.subtitle} variant="subtitle1">

--- a/src/public/search/SearchPageQuery.gql
+++ b/src/public/search/SearchPageQuery.gql
@@ -45,7 +45,7 @@ query SearchPageQuery(
   topHit: search(
     queryString: $queryString
     entityNames: $entityNames
-    page: { index: 0, size: 1}
+    page: { index: 0, size: 1 }
   ) {
     hits {
       object {
@@ -59,21 +59,11 @@ query SearchPageQuery(
             functions
             accessions
           }
-          associationsOnTheFly(page: { index: 0, size: 5 }) {
-            rows {
-              id
-            }
-          }
         }
         ... on Disease {
           id
           name
           description
-          associationsOnTheFly(page: { index: 0, size: 5 }) {
-            rows {
-              id
-            }
-          }
           therapeuticAreas {
             id
             name

--- a/src/public/search/TargetDetail.js
+++ b/src/public/search/TargetDetail.js
@@ -22,7 +22,6 @@ const TargetDetail = ({ classes, data }) => {
     approvedName,
     proteinAnnotations,
     bioType,
-    associationsOnTheFly: { rows },
   } = data;
 
   const functions = proteinAnnotations ? proteinAnnotations.functions : null;
@@ -39,21 +38,6 @@ const TargetDetail = ({ classes, data }) => {
           <TargetIcon className={classes.icon} /> Target
         </Typography>
         {functions ? <LongText lineLimit={4}>{functions[0]}</LongText> : null}
-        {/* temporarily hide top associated diseases */}
-        {/* rows.length > 0*/ false && (
-          <>
-            <Typography className={classes.subtitle} variant="subtitle1">
-              Top associated diseases or phenotypes
-            </Typography>
-            {rows.map(({ id }) => {
-              return (
-                <Fragment key={id}>
-                  <Link to={`/disease/${id}`}>{id}</Link>{' '}
-                </Fragment>
-              );
-            })}
-          </>
-        )}
         <Typography className={classes.subtitle} variant="subtitle1">
           Biotype
         </Typography>


### PR DESCRIPTION
Fixes [opentargets/platform#1118](https://github.com/opentargets/platform/issues/1118).

The code relevant to the display of relevant targets / associated disease has been removed too. We can refer to this commit if/when we need it back.