### PR TITLE
Lf fa icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@apollo/client": "^3.0.0-beta.44",
     "@clampy-js/react-clampy": "^1.2.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.29",
+    "@fortawesome/free-solid-svg-icons": "^5.13.1",
+    "@fortawesome/react-fontawesome": "^0.1.11",
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.50",

--- a/src/public/common/Header.js
+++ b/src/public/common/Header.js
@@ -3,15 +3,21 @@ import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Typography from '@material-ui/core/Typography';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 const styles = theme => ({
   titleContainer: {
     marginBottom: '10px',
   },
+  mainIconContainer: {
+    minWidth: '55px',
+    textAlign: 'center',
+  },
   mainIcon: {
-    width: '40px',
+    // width: '40px',
     height: '65px',
-    fill: theme.palette.primary.main,
-    marginRight: '12px',
+    color: theme.palette.primary.main,
+    // marginRight: '12px',
   },
   title: {
     color: theme.palette.primary.main,
@@ -35,8 +41,8 @@ const Header = ({
   <Grid className={classes.titleContainer} container justify="space-between">
     <Grid item zeroMinWidth>
       <Grid container wrap="nowrap">
-        <Grid item>
-          <Icon classes={{ root: classes.mainIcon }} />
+        <Grid item className={classes.mainIconContainer}>
+          <FontAwesomeIcon icon={Icon} size="3x" className={classes.mainIcon} />
         </Grid>
         <Grid item zeroMinWidth>
           <Grid container>

--- a/src/public/common/Header.js
+++ b/src/public/common/Header.js
@@ -10,8 +10,9 @@ const styles = theme => ({
     marginBottom: '10px',
   },
   mainIconContainer: {
-    minWidth: '55px',
+    width: '56px',
     textAlign: 'center',
+    marginRight: '4px',
   },
   mainIcon: {
     // width: '40px',

--- a/src/public/common/search/Option.js
+++ b/src/public/common/search/Option.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-
-import TargetIcon from '../../../icons/TargetIcon';
-import DiseaseIcon from '../../../icons/DiseaseIcon';
-import DrugIcon from '../../../icons/DrugIcon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
+import { faPrescriptionBottleAlt } from '@fortawesome/free-solid-svg-icons';
 
 const Search = ({ data }) => <Typography>Search for: {data.name}</Typography>;
 
 const TopHitDisease = ({ data }) => (
   <>
     <Typography variant="h4" color="primary">
-      <DiseaseIcon /> {data.name}
+      <FontAwesomeIcon icon={faStethoscope} size="xs" /> {data.name}
     </Typography>
     <Typography variant="caption" display="block" noWrap>
       {data.description}
@@ -21,7 +21,7 @@ const TopHitDisease = ({ data }) => (
 const TopHitDrug = ({ data }) => (
   <>
     <Typography variant="h4" color="primary">
-      <DrugIcon /> {data.name}
+      <FontAwesomeIcon icon={faPrescriptionBottleAlt} size="xs" /> {data.name}
     </Typography>
     {data.mechanismsOfAction ? (
       <Typography variant="caption" display="block" noWrap>
@@ -36,7 +36,7 @@ const TopHitDrug = ({ data }) => (
 const TopHitTarget = ({ data }) => (
   <>
     <Typography variant="h4" color="primary">
-      <TargetIcon /> {data.approvedSymbol}
+      <FontAwesomeIcon icon={faDna} size="xs" /> {data.approvedSymbol}
     </Typography>{' '}
     <Typography display="block" noWrap>
       {data.approvedName}

--- a/src/public/disease/Header.js
+++ b/src/public/disease/Header.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
+
 import Header from '../common/Header';
-import DiseaseIcon from '../../icons/DiseaseIcon';
 import EFO from './externalLinks/EFO';
 
 const DiseaseHeader = ({ efoId, name }) => (
   <Header
     title={name}
     subtitle={null}
-    Icon={DiseaseIcon}
+    Icon={faStethoscope}
     externalLinks={<EFO efoId={efoId} first />}
     rightContent={null}
   />

--- a/src/public/drug/Header.js
+++ b/src/public/drug/Header.js
@@ -1,14 +1,14 @@
 import React from 'react';
+import { faPrescriptionBottleAlt } from '@fortawesome/free-solid-svg-icons';
 
 import Header from '../common/Header';
-import DrugIcon from '../../icons/DrugIcon';
 import ChEMBL from './externalLinks/ChEMBL';
 
 const DrugHeader = ({ chemblId, name }) => (
   <Header
     title={name}
     subtitle={null}
-    Icon={DrugIcon}
+    Icon={faPrescriptionBottleAlt}
     externalLinks={<ChEMBL chemblId={chemblId} first />}
   />
 );

--- a/src/public/target/Header.js
+++ b/src/public/target/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
 
 import Header from '../common/Header';
-import TargetIcon from '../../icons/TargetIcon';
 import GeneticsLink from './GeneticsLink';
 import Ensembl from './externalLinks/Ensembl';
 import UniProt from './externalLinks/UniProt';
@@ -14,7 +14,7 @@ const TargetHeader = ({ ensgId, uniprotId, symbol, name }) => (
   <Header
     title={symbol}
     subtitle={name}
-    Icon={TargetIcon}
+    Icon={faDna}
     externalLinks={
       <React.Fragment>
         <Ensembl ensgId={ensgId} first />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,32 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
+"@fortawesome/fontawesome-common-types@^0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.29.tgz#e1a456b643237462d390304cab6975ff3fd68397"
+  integrity sha512-cY+QfDTbZ7XVxzx7jxbC98Oxr/zc7R2QpTLqTxqlfyXDrAJjzi/xUIqAUsygELB62JIrbsWxtSRhayKFkGI7MA==
+
+"@fortawesome/fontawesome-svg-core@^1.2.29":
+  version "1.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.29.tgz#34ef32824664534f9e4ef37982ebf286b899a189"
+  integrity sha512-xmPmP2t8qrdo8RyKihTkGb09RnZoc+7HFBCnr0/6ZhStdGDSLeEd7ajV181+2W29NWIFfylO13rU+s3fpy3cnA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/free-solid-svg-icons@^5.13.1":
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.1.tgz#010a846b718a0f110b3cd137d072639b4e8bd41a"
+  integrity sha512-LQH/0L1p4+rqtoSHa9qFYR84hpuRZKqaQ41cfBQx8b68p21zoWSekTAeA54I/2x9VlCHDLFlG74Nmdg4iTPQOg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/react-fontawesome@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz#c1a95a2bdb6a18fa97b355a563832e248bf6ef4a"
+  integrity sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
This PR adds the FontAwesome React package (Fortawesome) and updates the entity pages header icons to use the new SVG icons.
It retains the previous approach: 
common/Header expects a Icon props (with now that being a Fortawesome icon)
the Header component for each entity page (target, disease, drug) imports the icon and passes that on.

Closes https://github.com/opentargets/platform/issues/1072