### PR TITLE
Lf elem ids

### DIFF
--- a/src/public/common/Header.js
+++ b/src/public/common/Header.js
@@ -39,7 +39,12 @@ const Header = ({
   externalLinks,
   rightContent,
 }) => (
-  <Grid className={classes.titleContainer} container justify="space-between">
+  <Grid
+    className={classes.titleContainer}
+    container
+    justify="space-between"
+    id="profile-page-header-block"
+  >
     <Grid item zeroMinWidth>
       <Grid container wrap="nowrap">
         <Grid item className={classes.mainIconContainer}>

--- a/src/public/common/MiniWidgetBar.js
+++ b/src/public/common/MiniWidgetBar.js
@@ -4,7 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import MiniWidget from './MiniWidget';
 
 const MiniWidgetBar = ({ entity, data, onWidgetClick }) => (
-  <div style={{ paddingTop: 8, paddingBottom: 8 }}>
+  <div style={{ paddingTop: 8, paddingBottom: 8 }} id="summary-widget-section">
     <Grid container spacing={1}>
       {data.map(d => (
         <MiniWidget

--- a/src/public/common/SectionPanelsContainer.js
+++ b/src/public/common/SectionPanelsContainer.js
@@ -47,7 +47,7 @@ class SectionPanelsContainer extends React.Component {
       entitySectionsAccessor,
     } = this.props;
     return (
-      <div style={{ paddingTop: 8, paddingBottom: 8 }}>
+      <div style={{ paddingTop: 8, paddingBottom: 8 }} id="detail-view-section">
         <Grid container spacing={1}>
           <Hidden smDown>
             <Grid item md={2}>

--- a/src/public/search/DiseaseDetail.js
+++ b/src/public/search/DiseaseDetail.js
@@ -4,7 +4,9 @@ import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Link } from 'ot-ui';
 import LongText from '../common/LongText';
-import DiseaseIcon from '../../icons/DiseaseIcon';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
 
 const styles = () => ({
   link: {
@@ -12,9 +14,6 @@ const styles = () => ({
   },
   subtitle: {
     fontWeight: 500,
-  },
-  icon: {
-    verticalAlign: 'bottom',
   },
 });
 
@@ -26,7 +25,7 @@ const DiseaseDetail = ({ classes, data }) => {
         <Link to={`/disease/${id}`}>{name}</Link>
       </Typography>
       <Typography color="primary">
-        <DiseaseIcon className={classes.icon} /> Disease or phenotype
+        <FontAwesomeIcon icon={faStethoscope} size="md" /> Disease or phenotype
       </Typography>
       <LongText lineLimit={4}>{description}</LongText>
       {therapeuticAreas.length > 0 && (

--- a/src/public/search/DiseaseResult.js
+++ b/src/public/search/DiseaseResult.js
@@ -4,7 +4,9 @@ import Clampy from '@clampy-js/react-clampy';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Link } from 'ot-ui';
 import Highlights from '../common/Highlights';
-import DiseaseIcon from '../../icons/DiseaseIcon';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
 
 const styles = theme => ({
   container: {
@@ -16,7 +18,6 @@ const styles = theme => ({
   },
   icon: {
     color: theme.palette.primary.main,
-    verticalAlign: 'bottom',
   },
 });
 
@@ -24,7 +25,12 @@ const DiseaseResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
       <Link to={`/disease/${data.id}`} className={classes.subtitle}>
-        <DiseaseIcon className={classes.icon} /> {data.name}
+        <FontAwesomeIcon
+          icon={faStethoscope}
+          size="md"
+          className={classes.icon}
+        />{' '}
+        {data.name}
       </Link>
       {data.description && (
         <Typography variant="body2" component="div">

--- a/src/public/search/DrugDetail.js
+++ b/src/public/search/DrugDetail.js
@@ -9,7 +9,9 @@ import LongList from '../common/LongList';
 import WarningTooltip from '../common/WarningTooltip';
 import WithdrawnNotice from '../common/WithdrawnNotice';
 import Chip from '../common/Chip';
-import DrugIcon from '../../icons/DrugIcon';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPrescriptionBottleAlt } from '@fortawesome/free-solid-svg-icons';
 
 const useStyles = makeStyles({
   link: {
@@ -32,7 +34,7 @@ const DrugDetail = ({ data }) => {
         <Link to={`/drug/${data.id}`}>{data.name}</Link>
       </Typography>
       <Typography color="primary">
-        <DrugIcon className={classes.icon} /> Drug
+        <FontAwesomeIcon icon={faPrescriptionBottleAlt} size="md" /> Drug
       </Typography>
       <LongText lineLimit={4}>{data.description}</LongText>
       {data.hasBeenWithdrawn && (

--- a/src/public/search/DrugResult.js
+++ b/src/public/search/DrugResult.js
@@ -4,7 +4,10 @@ import Clampy from '@clampy-js/react-clampy';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Link } from 'ot-ui';
 import Highlights from '../common/Highlights';
-import DrugIcon from '../../icons/DrugIcon';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPrescriptionBottleAlt } from '@fortawesome/free-solid-svg-icons';
+
 const styles = theme => ({
   container: {
     marginBottom: '30px',
@@ -15,7 +18,6 @@ const styles = theme => ({
   },
   icon: {
     color: theme.palette.primary.main,
-    verticalAlign: 'bottom',
   },
 });
 
@@ -23,7 +25,12 @@ const DrugResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
       <Link to={`drug/${data.id}`} className={classes.subtitle}>
-        <DrugIcon className={classes.icon} /> {data.name}
+        <FontAwesomeIcon
+          icon={faPrescriptionBottleAlt}
+          size="md"
+          className={classes.icon}
+        />{' '}
+        {data.name}
       </Link>
       {data.description && (
         <Typography variant="body2" component="div">

--- a/src/public/search/Page.js
+++ b/src/public/search/Page.js
@@ -12,9 +12,6 @@ import TablePagination from '@material-ui/core/TablePagination';
 import BasePage from '../common/BasePage';
 import EmptyPage from '../common/EmptyPage';
 import ErrorBoundary from '../common/ErrorBoundary';
-import TargetIcon from '../../icons/TargetIcon';
-import DiseaseIcon from '../../icons/DiseaseIcon';
-import DrugIcon from '../../icons/DrugIcon';
 import TargetDetail from './TargetDetail';
 import DiseaseDetail from './DiseaseDetail';
 import DrugDetail from './DrugDetail';
@@ -22,6 +19,11 @@ import TargetResult from './TargetResult';
 import DiseaseResult from './DiseaseResult';
 import DrugResult from './DrugResult';
 import client from '../client';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
+import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
+import { faPrescriptionBottleAlt } from '@fortawesome/free-solid-svg-icons';
 
 const SEARCH_PAGE_QUERY = loader('./SearchPageQuery.gql');
 const QS_OPTIONS = {
@@ -58,20 +60,9 @@ const styles = theme => ({
   label: {
     marginLeft: '-6px',
   },
-  targetIcon: {
-    verticalAlign: 'bottom',
+  labelIcon: {
     color: theme.palette.primary.main,
-    marginRight: '14px',
-  },
-  diseaseIcon: {
-    verticalAlign: 'bottom',
-    color: theme.palette.primary.main,
-    marginRight: '3px',
-  },
-  drugIcon: {
-    verticalAlign: 'bottom',
-    color: theme.palette.primary.main,
-    marginRight: '8px',
+    marginRight: '2px',
   },
 });
 
@@ -91,7 +82,12 @@ const SearchFilters = withStyles(styles)(
           }
           label={
             <>
-              <TargetIcon className={classes.targetIcon} />
+              <FontAwesomeIcon
+                icon={faDna}
+                size="md"
+                fixedWidth
+                className={classes.labelIcon}
+              />
               <Typography variant="body2" display="inline">
                 Target ({counts.target})
               </Typography>
@@ -108,7 +104,12 @@ const SearchFilters = withStyles(styles)(
           }
           label={
             <>
-              <DiseaseIcon className={classes.diseaseIcon} />
+              <FontAwesomeIcon
+                icon={faStethoscope}
+                size="md"
+                fixedWidth
+                className={classes.labelIcon}
+              />
               <Typography variant="body2" display="inline">
                 Disease or phenotype ({counts.disease})
               </Typography>
@@ -125,7 +126,12 @@ const SearchFilters = withStyles(styles)(
           }
           label={
             <>
-              <DrugIcon className={classes.drugIcon} />
+              <FontAwesomeIcon
+                icon={faPrescriptionBottleAlt}
+                size="md"
+                fixedWidth
+                className={classes.labelIcon}
+              />
               <Typography variant="body2" display="inline">
                 Drug ({counts.drug})
               </Typography>

--- a/src/public/search/TargetDetail.js
+++ b/src/public/search/TargetDetail.js
@@ -4,14 +4,13 @@ import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Link } from 'ot-ui';
 import LongText from '../common/LongText';
-import TargetIcon from '../../icons/TargetIcon';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
 
 const styles = () => ({
   subtitle: {
     fontWeight: 500,
-  },
-  icon: {
-    verticalAlign: 'bottom',
   },
 });
 
@@ -35,7 +34,7 @@ const TargetDetail = ({ classes, data }) => {
         </Typography>
         <Typography variant="subtitle2">{approvedName}</Typography>
         <Typography color="primary">
-          <TargetIcon className={classes.icon} /> Target
+          <FontAwesomeIcon icon={faDna} size="md" /> Target
         </Typography>
         {functions ? <LongText lineLimit={4}>{functions[0]}</LongText> : null}
         <Typography className={classes.subtitle} variant="subtitle1">

--- a/src/public/search/TargetResult.js
+++ b/src/public/search/TargetResult.js
@@ -3,8 +3,10 @@ import Clampy from '@clampy-js/react-clampy';
 import Typography from '@material-ui/core/Typography';
 import { Link } from 'ot-ui';
 import Highlights from '../common/Highlights';
-import TargetIcon from '../../icons/TargetIcon';
 import withStyles from '@material-ui/core/styles/withStyles';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faDna } from '@fortawesome/free-solid-svg-icons';
 
 const styles = theme => ({
   container: {
@@ -16,7 +18,6 @@ const styles = theme => ({
   },
   icon: {
     color: theme.palette.primary.main,
-    verticalAlign: 'bottom',
   },
 });
 
@@ -24,7 +25,8 @@ const TargetResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
       <Link to={`/target/${data.id}`} className={classes.subtitle}>
-        <TargetIcon className={classes.icon} /> {data.approvedSymbol}
+        <FontAwesomeIcon icon={faDna} size="md" className={classes.icon} />{' '}
+        {data.approvedSymbol}
       </Link>
       {data.proteinAnnotations ? (
         <Typography variant="body2" component="div">


### PR DESCRIPTION
This PR addresses 2 (unrelated) issues:
1. adds basic section ids for the profile pages (header, summary, sections block) as per https://github.com/opentargets/platform/issues/1152
2. updates the icons on the search page, which had been previously left out: https://github.com/opentargets/platform/issues/1072

A note on ids:
ids are currently hardcoded in the relevant core component; this means they are the same for each profile page (which is intended, os not an issue).
They'll probably also be the same in the evidence page, as we will likely use the same components (header, summary, etc): in there we might not want the id being "profile-page-header-block" as it will not be a profile page (although the structure is the same). So we might want to change that, or to make the components (header etc) take a prop `id` configured from each page. Might be something we want to do now, might be something for later.