### PR TITLE
Change path structure

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import DownloadsPage from './pages/DownloadsPage';
 import DrugPage from './pages/DrugPage';
 import TargetPage from './pages/TargetPage';
 import EvidenceByDatatypePage from './pages/EvidenceByDatatypePage';
-import notFoundPage from './pages/NotFoundPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 class App extends Component {
   componentDidMount() {
@@ -38,7 +38,7 @@ class App extends Component {
                   path="/evidence/:ensgId/:efoId"
                   component={EvidenceByDatatypePage}
                 />
-                <Route component={notFoundPage} />
+                <Route component={NotFoundPage} />
               </Switch>
             </GoogleAnalyticsWrapper>
           </Router>

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ class App extends Component {
                 <Route path="/downloads" component={DownloadsPage} />
                 <Route path="/disease/:efoId" component={DiseasePage} />
                 <Route path="/target/:ensgId" component={TargetPage} />
-                <Route path="/drug/:chemblId/profile" component={DrugPage} />
+                <Route path="/drug/:chemblId" component={DrugPage} />
                 <Route
                   path="/evidence/:ensgId/:efoId"
                   component={EvidenceByDatatypePage}

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -64,7 +64,7 @@ function Search({ autoFocus = false, embedded = false }) {
     } else {
       history.push(
         `/${option.entity}/${option.id}${
-          option.entity === 'drug' ? '/profile' : ''
+          option.entity !== 'drug' ? '/associations' : ''
         }`
       );
     }

--- a/src/pages/DiseasePage/DiseasePage.js
+++ b/src/pages/DiseasePage/DiseasePage.js
@@ -46,12 +46,12 @@ function DiseasePage({ history, location, match }) {
       <RoutingTabs>
         <RoutingTab
           label="Associated targets"
-          path="/disease/:efoId"
+          path="/disease/:efoId/associations"
           component={() => <ClassicAssociations efoId={efoId} name={name} />}
         />
         <RoutingTab
           label="Profile"
-          path="/disease/:efoId/profile"
+          path="/disease/:efoId"
           component={() => (
             <Profile
               efoId={efoId}

--- a/src/pages/DrugPage/DrugPage.js
+++ b/src/pages/DrugPage/DrugPage.js
@@ -32,7 +32,7 @@ const DRUG_PAGE_QUERY = gql`
   }
 `;
 
-const DrugPage = ({ match, history, location }) => {
+const DrugPage = ({ match }) => {
   const { chemblId } = match.params;
   const { loading, data } = useQuery(DRUG_PAGE_QUERY, {
     variables: { chemblId },
@@ -55,7 +55,7 @@ const DrugPage = ({ match, history, location }) => {
       <RoutingTabs>
         <RoutingTab
           label="Profile"
-          path="/drug/:chemblId/profile"
+          path="/drug/:chemblId"
           component={() => (
             <Profile
               chemblId={chemblId}

--- a/src/pages/EmptyPage/EmptyPage.js
+++ b/src/pages/EmptyPage/EmptyPage.js
@@ -35,11 +35,11 @@ const EmptyPage = ({ classes, children }) => {
       <Typography className={classes.suggestions} variant="caption">
         <Grid container justify="space-between">
           Try:
-          <Link to="/target/ENSG00000105810">CDK6</Link>
-          <Link to="/disease/EFO_0003086">kidney disease</Link>
-          <Link to="/target/ENSG00000145777">ENSG00000145777</Link>
-          <Link to="/drug/CHEMBL112/profile">acetaminophen</Link>
-          <Link to="/drug/CHEMBL3137343/profile">Keytruda</Link>
+          <Link to="/target/ENSG00000105810/associations">CDK6</Link>
+          <Link to="/disease/EFO_0003086/associations">kidney disease</Link>
+          <Link to="/target/ENSG00000145777/associations">ENSG00000145777</Link>
+          <Link to="/drug/CHEMBL112">acetaminophen</Link>
+          <Link to="/drug/CHEMBL3137343">Keytruda</Link>
         </Grid>
       </Typography>
       <Typography gutterBottom>You might also want to ...</Typography>

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -48,12 +48,20 @@ const HomePage = () => {
         <HomeBox>
           <Search autoFocus />
           <Grid className={classes.links} container justify="space-around">
-            <Link to={`/target/${targets[0].id}`}>{targets[0].label}</Link>
-            <Link to={`/target/${targets[1].id}`}>{targets[1].label}</Link>
-            <Link to={`/disease/${diseases[0].id}`}>{diseases[0].label}</Link>
-            <Link to={`/disease/${diseases[1].id}`}>{diseases[1].label}</Link>
-            <Link to={`/drug/${drugs[0].id}/profile`}>{drugs[0].label}</Link>
-            <Link to={`/drug/${drugs[1].id}/profile`}>{drugs[1].label}</Link>
+            <Link to={`/target/${targets[0].id}/associations`}>
+              {targets[0].label}
+            </Link>
+            <Link to={`/target/${targets[1].id}/associations`}>
+              {targets[1].label}
+            </Link>
+            <Link to={`/disease/${diseases[0].id}/associations`}>
+              {diseases[0].label}
+            </Link>
+            <Link to={`/disease/${diseases[1].id}/associations`}>
+              {diseases[1].label}
+            </Link>
+            <Link to={`/drug/${drugs[0].id}`}>{drugs[0].label}</Link>
+            <Link to={`/drug/${drugs[1].id}`}>{drugs[1].label}</Link>
           </Grid>
           <Grid
             className={classes.api}

--- a/src/pages/SearchPage/DiseaseDetail.js
+++ b/src/pages/SearchPage/DiseaseDetail.js
@@ -21,7 +21,7 @@ const DiseaseDetail = ({ classes, data }) => {
   return (
     <CardContent>
       <Typography color="primary" variant="h5">
-        <Link to={`/disease/${id}`}>{name}</Link>
+        <Link to={`/disease/${id}/associations`}>{name}</Link>
       </Typography>
       <Typography color="primary">
         <FontAwesomeIcon icon={faStethoscope} size="md" /> Disease or phenotype

--- a/src/pages/SearchPage/DiseaseResult.js
+++ b/src/pages/SearchPage/DiseaseResult.js
@@ -24,7 +24,10 @@ const styles = theme => ({
 const DiseaseResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
-      <Link to={`/disease/${data.id}`} className={classes.subtitle}>
+      <Link
+        to={`/disease/${data.id}/associations`}
+        className={classes.subtitle}
+      >
         <FontAwesomeIcon
           icon={faStethoscope}
           size="md"

--- a/src/pages/SearchPage/DrugDetail.js
+++ b/src/pages/SearchPage/DrugDetail.js
@@ -30,7 +30,7 @@ const DrugDetail = ({ data }) => {
   return (
     <CardContent>
       <Typography color="primary" variant="h5">
-        <Link to={`/drug/${data.id}/profile`}>{data.name}</Link>
+        <Link to={`/drug/${data.id}`}>{data.name}</Link>
       </Typography>
       <Typography color="primary">
         <FontAwesomeIcon icon={faPrescriptionBottleAlt} size="md" /> Drug

--- a/src/pages/SearchPage/DrugResult.js
+++ b/src/pages/SearchPage/DrugResult.js
@@ -24,7 +24,7 @@ const styles = theme => ({
 const DrugResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
-      <Link to={`drug/${data.id}/profile`} className={classes.subtitle}>
+      <Link to={`drug/${data.id}`} className={classes.subtitle}>
         <FontAwesomeIcon
           icon={faPrescriptionBottleAlt}
           size="md"

--- a/src/pages/SearchPage/TargetDetail.js
+++ b/src/pages/SearchPage/TargetDetail.js
@@ -29,7 +29,7 @@ const TargetDetail = ({ classes, data }) => {
     <>
       <CardContent>
         <Typography color="primary" variant="h5">
-          <Link to={`/target/${id}`}>{approvedSymbol}</Link>
+          <Link to={`/target/${id}/associations`}>{approvedSymbol}</Link>
         </Typography>
         <Typography variant="subtitle2">{approvedName}</Typography>
         <Typography color="primary">

--- a/src/pages/SearchPage/TargetResult.js
+++ b/src/pages/SearchPage/TargetResult.js
@@ -24,7 +24,7 @@ const styles = theme => ({
 const TargetResult = ({ classes, data, highlights }) => {
   return (
     <div className={classes.container}>
-      <Link to={`/target/${data.id}`} className={classes.subtitle}>
+      <Link to={`/target/${data.id}/associations`} className={classes.subtitle}>
         <FontAwesomeIcon icon={faDna} size="md" className={classes.icon} />{' '}
         {data.approvedSymbol}
       </Link>

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -1,5 +1,12 @@
 import React, { useState } from 'react';
 import {
+  Switch,
+  Route,
+  Link,
+  useRouteMatch,
+  useLocation,
+} from 'react-router-dom';
+import {
   Card,
   CardContent,
   Grid,
@@ -47,15 +54,12 @@ const TARGET_ASSOCIATIONS_QUERY = gql`
 `;
 
 function ClassicAssociations({ ensgId, symbol }) {
-  const [tab, setTab] = useState('heatmap');
+  const match = useRouteMatch();
+  const location = useLocation();
   const [aggregationFilters, setAggregationFilters] = useState([]);
   const { loading, data, refetch } = useQuery(TARGET_ASSOCIATIONS_QUERY, {
     variables: { ensemblId: ensgId, aggregationFilters },
   });
-
-  const handleTabChange = (_, tab) => {
-    setTab(tab);
-  };
 
   const handleChangeFilters = newFilters => {
     setAggregationFilters(newFilters);
@@ -92,45 +96,55 @@ function ClassicAssociations({ ensgId, symbol }) {
         </Card>
       </Grid>
       <Grid item xs={12} lg={9}>
-        <Tabs
-          value={tab}
-          onChange={handleTabChange}
-          variant="scrollable"
-          scrollButtons="auto"
-        >
-          <Tab value="heatmap" label="Table" />
-          <Tab value="bubbles" label="Bubbles" />
-          <Tab value="dag" label="Graph" />
+        <Tabs value={location.pathname}>
+          <Tab
+            component={Link}
+            value={match.url}
+            label="Table"
+            to={match.url}
+          />
+          <Tab
+            component={Link}
+            value={`${match.url}/bubbles`}
+            label="Bubbles"
+            to={`${match.url}/bubbles`}
+          />
+          <Tab
+            component={Link}
+            value={`${match.url}/graph`}
+            label="Graph"
+            to={`${match.url}/graph`}
+          />
         </Tabs>
         <Card elevation={0} style={{ overflow: 'visible' }}>
           <CardContent>
             {loading && !data ? (
               <Skeleton variant="rect" height="40vh" />
             ) : (
-              <>
-                {tab === 'heatmap' && (
-                  <ClassicAssociationsTable
-                    ensgId={ensgId}
-                    aggregationFilters={aggregationFilters}
-                  />
-                )}
-                {tab === 'bubbles' && (
+              <Switch>
+                <Route path={`${match.path}/bubbles`}>
                   <Wrapper
                     ensemblId={ensgId}
                     symbol={symbol}
                     Component={ClassicAssociationsBubbles}
                     aggregationFilters={aggregationFilters}
                   />
-                )}
-                {tab === 'dag' && (
+                </Route>
+                <Route path={`${match.path}/graph`}>
                   <Wrapper
                     ensemblId={ensgId}
                     symbol={symbol}
                     Component={ClassicAssociationsDAG}
                     aggregationFilters={aggregationFilters}
                   />
-                )}
-              </>
+                </Route>
+                <Route path={match.path}>
+                  <ClassicAssociationsTable
+                    ensgId={ensgId}
+                    aggregationFilters={aggregationFilters}
+                  />
+                </Route>
+              </Switch>
             )}
           </CardContent>
         </Card>

--- a/src/pages/TargetPage/TargetPage.js
+++ b/src/pages/TargetPage/TargetPage.js
@@ -59,7 +59,7 @@ const TargetPage = ({ history, location, match }) => {
       <RoutingTabs>
         <RoutingTab
           label="Associated diseases"
-          path="/target/:ensgId"
+          path="/target/:ensgId/associations"
           component={() => (
             <ClassicAssociations
               ensgId={ensgId}
@@ -71,7 +71,7 @@ const TargetPage = ({ history, location, match }) => {
         />
         <RoutingTab
           label="Profile"
-          path="/target/:ensgId/profile"
+          path="/target/:ensgId"
           component={() => (
             <Profile
               ensgId={ensgId}

--- a/src/pages/TargetPage/TargetPage.js
+++ b/src/pages/TargetPage/TargetPage.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { gql, useQuery } from '@apollo/client';
-import { Redirect } from 'react-router-dom';
+import { Redirect, Switch, Route, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import { Tabs, Tab } from '@material-ui/core';
 
 import BasePage from '../../components/BasePage';
 import ClassicAssociations from './ClassicAssociations';
 import Header from './Header';
 import { oldPlatformUrl } from '../../constants';
 import Profile from './Profile';
-import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
 
 const TARGET_PAGE_QUERY = gql`
   query TargetQuery($ensgId: String!) {
@@ -28,7 +28,7 @@ const TARGET_PAGE_QUERY = gql`
   }
 `;
 
-const TargetPage = ({ history, location, match }) => {
+const TargetPage = ({ location, match }) => {
   const { ensgId } = match.params;
 
   const { loading, data } = useQuery(TARGET_PAGE_QUERY, {
@@ -56,38 +56,51 @@ const TargetPage = ({ history, location, match }) => {
         symbol={symbol}
         name={name}
       />
-      <RoutingTabs>
-        <RoutingTab
+      <Tabs
+        value={
+          location.pathname.includes('associations')
+            ? `${match.url}/associations`
+            : location.pathname
+        }
+      >
+        <Tab
+          value={`${match.url}/associations`}
+          component={Link}
+          to={`${match.url}/associations`}
           label="Associated diseases"
-          path="/target/:ensgId/associations"
-          component={() => (
-            <ClassicAssociations
-              ensgId={ensgId}
-              uniprotId={uniprotId}
-              symbol={symbol}
-              name={name}
-            />
-          )}
         />
-        <RoutingTab
+        <Tab
+          value={match.url}
+          component={Link}
           label="Profile"
-          path="/target/:ensgId"
-          component={() => (
-            <Profile
-              ensgId={ensgId}
-              uniprotId={uniprotId}
-              symbol={symbol}
-              name={name}
-              synonyms={synonyms}
-              description={description}
-            />
-          )}
+          to={match.url}
         />
-        <RoutingTab
+        <Tab
+          component="a"
+          href={`${oldPlatformUrl}/target/${ensgId}/associations`}
           label="Classic view"
-          url={`${oldPlatformUrl}/target/${ensgId}/associations`}
         />
-      </RoutingTabs>
+      </Tabs>
+      <Switch>
+        <Route path={`${match.path}/associations`}>
+          <ClassicAssociations
+            ensgId={ensgId}
+            uniprotId={uniprotId}
+            symbol={symbol}
+            name={name}
+          />
+        </Route>
+        <Route path={match.path}>
+          <Profile
+            ensgId={ensgId}
+            uniprotId={uniprotId}
+            symbol={symbol}
+            name={name}
+            synonyms={synonyms}
+            description={description}
+          />
+        </Route>
+      </Switch>
     </BasePage>
   );
 };

--- a/src/sections/common/KnownDrugs/custom/FilterTable.js
+++ b/src/sections/common/KnownDrugs/custom/FilterTable.js
@@ -75,9 +75,7 @@ const getColumns = ({ filters }) => {
       id: 'drug',
       label: 'Drug',
       renderCell: d => (
-        <Link to={'/drug/' + d.drug.id + '/profile'}>
-          {_.capitalize(d.drug.name)}
-        </Link>
+        <Link to={'/drug/' + d.drug.id}>{_.capitalize(d.drug.name)}</Link>
       ),
       comparator: generateComparatorFromAccessor(d => d.drug.name),
       export: d => d.drug.name,

--- a/src/sections/disease/KnownDrugs/Section.js
+++ b/src/sections/disease/KnownDrugs/Section.js
@@ -48,9 +48,7 @@ const columnPool = {
       {
         id: 'drug',
         propertyPath: 'drug.id',
-        renderCell: d => (
-          <Link to={`/drug/${d.drug.id}/profile`}>{d.drug.name}</Link>
-        ),
+        renderCell: d => <Link to={`/drug/${d.drug.id}`}>{d.drug.name}</Link>,
       },
       {
         id: 'type',

--- a/src/sections/drug/KnownDrugs/Section.js
+++ b/src/sections/drug/KnownDrugs/Section.js
@@ -48,9 +48,7 @@ const columnPool = {
       {
         id: 'drug',
         propertyPath: 'drug.id',
-        renderCell: d => (
-          <Link to={`/drug/${d.drug.id}/profile`}>{d.drug.name}</Link>
-        ),
+        renderCell: d => <Link to={`/drug/${d.drug.id}`}>{d.drug.name}</Link>,
       },
       {
         id: 'type',

--- a/src/sections/target/KnownDrugs/Section.js
+++ b/src/sections/target/KnownDrugs/Section.js
@@ -48,9 +48,7 @@ const columnPool = {
       {
         id: 'drug',
         propertyPath: 'drug.id',
-        renderCell: d => (
-          <Link to={`/drug/${d.drug.id}/profile`}>{d.drug.name}</Link>
-        ),
+        renderCell: d => <Link to={`/drug/${d.drug.id}`}>{d.drug.name}</Link>,
       },
       {
         id: 'type',


### PR DESCRIPTION
As discussed, this PR changes the path structure to:
- entity/ID/associations for the heat map associations view
- entity/ID/associations/bubbles for the bubbles view
- entity/ID/associations/graph for the graph view
- entity/ID for the profile pages

And in terms of search behaviour:
- When a user searches for a disease or target and they click on a result, we take them to the disease or target heat map associations page
- When a user searches for a drug and they click on a result, we take them to the drug profile page