### PR TITLE
Do not wait for data to show description

### DIFF
--- a/src/components/Section/SectionItem.js
+++ b/src/components/Section/SectionItem.js
@@ -68,7 +68,7 @@ function SectionItem({
                     [classes.descriptionError]: error,
                   })}
                 >
-                  {data && renderDescription(data)}
+                  {renderDescription()}
                 </Typography>
               }
               action={tags}


### PR DESCRIPTION
After implementing all sections in every page, we've found out we don't really need the section body data to render the description. They always use the ids, names or symbols.

This PR removes the wait for the `data` from the section description so it also renders while sections are loading. Consequently, `data` is not passed as parameter anymore to descriptions (which they were not using anyway).