### PR TITLE
Switch react-select for material-ui autocomplete

### DIFF
--- a/src/components/FilteringOtTableRF.js
+++ b/src/components/FilteringOtTableRF.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { OtTableRF } from 'ot-ui';
-import Select from 'react-select';
+import { Autocomplete } from '@material-ui/lab';
 import crossfilter from 'crossfilter2';
+import { OtTableRF } from 'ot-ui';
+import { TextField, Typography } from '@material-ui/core';
 import _ from 'lodash';
 
 const FilteringOtTableRF = props => {
@@ -55,16 +56,16 @@ const filterDropdown = (
   dimensions[columnId] = dimensions[columnId] || xf.dimension(valueAccessor);
   const dim = dimensions[columnId];
   return () => {
-    const handler = selection => {
+    const handler = (e, selection) => {
       if (selection) {
         dim.filter(cellValue => {
           if (_.isArray(cellValue)) {
             return _.some(
               cellValue,
-              arrayElement => arrayElement === selection.value
+              arrayElement => arrayElement === selection
             );
           } else {
-            return cellValue === selection.value;
+            return cellValue === selection;
           }
         });
       } else {
@@ -81,11 +82,19 @@ const filterDropdown = (
         return [cellValue];
       }
     });
-    const options = _.sortedUniq(cellValues.sort()).map(value => ({
-      label: value,
-      value: value,
-    }));
-    return <Select isClearable options={options} onChange={handler} />;
+    const options = _.sortedUniq(cellValues.sort());
+    return (
+      <Autocomplete
+        options={options}
+        onChange={handler}
+        renderInput={params => (
+          <TextField {...params} label="Select..." margin="normal" />
+        )}
+        renderOption={option => (
+          <Typography style={{ fontSize: '.85rem' }}>{option}</Typography>
+        )}
+      />
+    );
   };
 };
 

--- a/src/sections/common/Bibliography/Body.js
+++ b/src/sections/common/Bibliography/Body.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
-import Select from 'react-select';
-import { Chip, Grid, withStyles } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import { Chip, Grid, TextField, withStyles } from '@material-ui/core';
 import classNames from 'classnames';
 
 import { Typography, Button } from 'ot-ui';
@@ -23,6 +23,9 @@ const aggtype = [
 ];
 
 const styles = theme => ({
+  aggtypeAutocomplete: {
+    maxWidth: '15rem',
+  },
   icon: {
     width: '50px',
     height: '50px',
@@ -30,10 +33,6 @@ const styles = theme => ({
   },
   iconNoData: {
     fill: '#e2dfdf',
-  },
-  dropDown: {
-    maxWidth: '200px',
-    marginBottom: '20px',
   },
   chip: {
     margin: theme.spacing(0.25),
@@ -67,7 +66,7 @@ class Section extends Component {
   }
 
   // Handler for drop down menu
-  aggtypeFilterHandler = selection => {
+  aggtypeFilterHandler = (e, selection) => {
     this.setState({ selectedAggregation: selection });
   };
 
@@ -212,13 +211,22 @@ class Section extends Component {
           >
             <Grid item xs={12}>
               {/* Dropdown menu */}
-              <Select
-                options={aggtype}
-                defaultValue={selectedAggregation}
+              <Autocomplete
+                className={classes.aggtypeAutocomplete}
+                disableClearable
+                getOptionLabel={option => option.label}
+                getOptionSelected={option => option.value}
                 onChange={this.aggtypeFilterHandler}
-                className={classNames(classes.dropDown)}
+                options={aggtype}
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    // label=""
+                    margin="normal"
+                  />
+                )}
+                value={selectedAggregation}
               />
-
               {/* Chips */}
               <Fragment>
                 {selected.map((sel, i) => {

--- a/src/sections/target/GeneOntology/OntologyTable.js
+++ b/src/sections/target/GeneOntology/OntologyTable.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
-import Select from 'react-select';
+import { Autocomplete } from '@material-ui/lab';
 import crossfilter from 'crossfilter2';
+import { TextField } from '@material-ui/core';
 import _ from 'lodash';
 
 import { OtTableRF, DataDownloader, Link } from 'ot-ui';
@@ -22,10 +23,14 @@ const getColumns = (
       label: 'Category',
       renderCell: row => capitalizeSnakeCase(row.category),
       renderFilter: () => (
-        <Select
-          isClearable
+        <Autocomplete
           options={categoryOptions}
+          getOptionLabel={option => option.label}
+          getOptionSelected={option => option.value}
           onChange={categoryFilterHandler}
+          renderInput={params => (
+            <TextField {...params} label="Select..." margin="normal" />
+          )}
         />
       ),
     },
@@ -43,10 +48,14 @@ const getColumns = (
         );
       },
       renderFilter: () => (
-        <Select
-          isClearable
+        <Autocomplete
           options={termOptions}
+          getOptionLabel={option => option.label}
+          getOptionSelected={option => option.value}
           onChange={termFilterHandler}
+          renderInput={params => (
+            <TextField {...params} label="Select..." margin="normal" />
+          )}
         />
       ),
     },
@@ -94,7 +103,7 @@ class OntologyTable extends Component {
     filteredRows: this.props.rows,
   };
 
-  categoryFilterHandler = selection => {
+  categoryFilterHandler = (e, selection) => {
     const { ontologyXf, categoryDim } = this;
 
     if (selection) {
@@ -106,7 +115,7 @@ class OntologyTable extends Component {
     this.setState({ filteredRows: ontologyXf.allFiltered() });
   };
 
-  termFilterHandler = selection => {
+  termFilterHandler = (e, selection) => {
     const { ontologyXf, termDim } = this;
 
     if (selection) {

--- a/src/sections/target/MousePhenotypes/PhenotypesTable.js
+++ b/src/sections/target/MousePhenotypes/PhenotypesTable.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
-import Select from 'react-select';
+import { Autocomplete } from '@material-ui/lab';
 import crossfilter from 'crossfilter2';
+import { TextField } from '@material-ui/core';
 import _ from 'lodash';
 
 import { DataDownloader, OtTableRF, Link } from 'ot-ui';
@@ -13,8 +14,7 @@ const getColumns = (
   categoryOptions,
   categoryFilterHandler,
   phenotypeOptions,
-  phenotypeFilterHandler,
-  classes
+  phenotypeFilterHandler
 ) => {
   return [
     {
@@ -29,10 +29,14 @@ const getColumns = (
         </Link>
       ),
       renderFilter: () => (
-        <Select
-          isClearable
-          options={mouseGeneOptions}
+        <Autocomplete
+          getOptionLabel={option => option.label}
+          getOptionSelected={option => option.value}
           onChange={mouseGeneFilterHandler}
+          options={mouseGeneOptions}
+          renderInput={params => (
+            <TextField {...params} label="Select..." margin="normal" />
+          )}
         />
       ),
     },
@@ -40,10 +44,14 @@ const getColumns = (
       id: 'categoryLabel',
       label: 'Phenotype category',
       renderFilter: () => (
-        <Select
-          isClearable
+        <Autocomplete
+          getOptionLabel={option => option.label}
+          getOptionSelected={option => option.value}
           options={categoryOptions}
           onChange={categoryFilterHandler}
+          renderInput={params => (
+            <TextField {...params} label="Select..." margin="normal" />
+          )}
         />
       ),
     },
@@ -51,10 +59,14 @@ const getColumns = (
       id: 'phenotypeLabel',
       label: 'Phenotype label',
       renderFilter: () => (
-        <Select
-          isClearable
+        <Autocomplete
+          getOptionLabel={option => option.label}
+          getOptionSelected={option => option.value}
           options={phenotypeOptions}
           onChange={phenotypeFilterHandler}
+          renderInput={params => (
+            <TextField {...params} label="Select..." margin="normal" />
+          )}
         />
       ),
     },
@@ -133,7 +145,7 @@ class PhenotypesTable extends Component {
     filteredRows: this.props.rows,
   };
 
-  mouseGeneFilterHandler = selection => {
+  mouseGeneFilterHandler = (e, selection) => {
     const { phenotypesXf, mouseGeneDim } = this;
 
     if (selection) {
@@ -145,7 +157,7 @@ class PhenotypesTable extends Component {
     this.setState({ filteredRows: phenotypesXf.allFiltered() });
   };
 
-  categoryFilterHandler = selection => {
+  categoryFilterHandler = (e, selection) => {
     const { phenotypesXf, categoryDim } = this;
     if (selection) {
       categoryDim.filter(d => d === selection.value);
@@ -156,7 +168,7 @@ class PhenotypesTable extends Component {
     this.setState({ filteredRows: phenotypesXf.allFiltered() });
   };
 
-  phenotypeFilterHandler = selection => {
+  phenotypeFilterHandler = (e, selection) => {
     const { phenotypesXf, phenotypeDim } = this;
 
     if (selection) {


### PR DESCRIPTION
This lets us remove `react-select` library from the bundle, and unifies the look and feel of dropdowns.