### PR TITLE
20.11 release evidence page fixes and changes

### DIFF
--- a/src/components/ScientificNotation.js
+++ b/src/components/ScientificNotation.js
@@ -5,10 +5,16 @@ import { decimalPlaces } from '../constants';
 function ScientificNotation({ number }) {
   if (!number) return null;
 
-  let [mantissa, exponent] = number.toExponential().split('e');
+  let mantissa, exponent;
+
+  if (Array.isArray(number)) {
+    [mantissa, exponent] = number;
+  } else {
+    [mantissa, exponent] = number.toExponential().split('e');
+    exponent = exponent.charAt(0) === '+' ? exponent.slice(1) : exponent;
+  }
 
   mantissa = parseFloat(parseFloat(mantissa).toFixed(decimalPlaces));
-  exponent = exponent.charAt(0) === '+' ? exponent.slice(1) : exponent;
 
   return (
     <>

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -14,12 +14,12 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function Tooltip({ children, title, ...props }) {
+function Tooltip({ children, title, showHelpIcon = false, ...props }) {
   const classes = useStyles();
 
   return (
     <>
-      {children}
+      {showHelpIcon && children}
       <MUITooltip
         placement="top"
         interactive
@@ -27,7 +27,7 @@ function Tooltip({ children, title, ...props }) {
         title={title}
         {...props}
       >
-        <Help className={classes.tooltipIcon} />
+        {showHelpIcon ? <Help className={classes.tooltipIcon} /> : children}
       </MUITooltip>
     </>
   );

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Help } from '@material-ui/icons';
+import { makeStyles, Tooltip as MUITooltip } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  tooltip: {
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.grey[300]}`,
+    color: theme.palette.text.primary,
+  },
+  tooltipIcon: {
+    fontSize: '.75rem',
+    marginBottom: '.2rem',
+  },
+}));
+
+function Tooltip({ children, title, ...props }) {
+  const classes = useStyles();
+
+  return (
+    <>
+      {children}
+      <MUITooltip
+        placement="top"
+        interactive
+        classes={{ tooltip: classes.tooltip }}
+        title={title}
+        {...props}
+      >
+        <Help className={classes.tooltipIcon} />
+      </MUITooltip>
+    </>
+  );
+}
+
+export default Tooltip;

--- a/src/sections/evidence/CancerGeneCensus/sectionQuery.gql
+++ b/src/sections/evidence/CancerGeneCensus/sectionQuery.gql
@@ -1,0 +1,39 @@
+query CancerGeneCensusQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
+  disease(efoId: $efoId) {
+    id
+    evidences(
+      ensemblIds: [$ensemblId]
+      enableIndirect: true
+      datasourceIds: ["cancer_gene_census"]
+      size: $size
+    ) {
+      rows {
+        disease {
+          id
+          name
+        }
+        mutatedSamples {
+          functionalConsequence {
+            id
+            label
+          }
+          numberSamplesWithMutationType
+          numberSamplesTested
+        }
+        literature
+      }
+    }
+  }
+  target(ensemblId: $ensemblId) {
+    id
+    hallmarks {
+      attributes {
+        reference {
+          pubmedId
+          description
+        }
+        name
+      }
+    }
+  }
+}

--- a/src/sections/evidence/GenomicsEngland/Body.js
+++ b/src/sections/evidence/GenomicsEngland/Body.js
@@ -6,7 +6,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { loader } from 'graphql.macro';
-import { List, ListItem, Typography } from '@material-ui/core';
+import { List, ListItem } from '@material-ui/core';
 
 import { Link } from 'ot-ui';
 
@@ -73,7 +73,7 @@ const columns = [
       cohortPhenotypes ? (
         <List style={{ padding: 0 }}>
           {cohortPhenotypes.map((entry, index) => (
-            <ListItem key={index} style={{ padding: '0 0 .5rem 0' }}>
+            <ListItem key={index} style={{ padding: '.25rem 0' }}>
               {entry}
             </ListItem>
           ))}

--- a/src/sections/evidence/GenomicsEngland/Body.js
+++ b/src/sections/evidence/GenomicsEngland/Body.js
@@ -1,22 +1,57 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
+import {
+  faCheckSquare,
+  faExclamationTriangle,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { loader } from 'graphql.macro';
+import { List, ListItem, Typography } from '@material-ui/core';
+
 import { Link } from 'ot-ui';
 
 import { betaClient } from '../../../client';
 import { DataTable, TableDrawer } from '../../../components/Table';
 import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
+import { epmcUrl } from '../../../utils/urls';
 import { sentenceCase } from '../../../utils/global';
 import SectionItem from '../../../components/Section/SectionItem';
 import Summary from './Summary';
 import usePlatformApi from '../../../hooks/usePlatformApi';
-import { epmcUrl } from '../../../utils/urls';
+import Tooltip from '../../../components/Tooltip';
 
 const geUrl = (id, approvedSymbol) =>
   `https://panelapp.genomicsengland.co.uk/panels/${id}/gene/${approvedSymbol}`;
 
 const GENOMICS_ENGLAND_QUERY = loader('./sectionQuery.gql');
+
+const confidenceCaption = confidence =>
+  ({
+    green: (
+      <span style={{ color: '#3fad46' }}>
+        <FontAwesomeIcon icon={faCheckSquare} size="sm" />{' '}
+        {sentenceCase(confidence)}
+      </span>
+    ),
+    amber: (
+      <span style={{ color: '#f0ad4e' }}>
+        <FontAwesomeIcon icon={faExclamationTriangle} size="sm" />{' '}
+        {sentenceCase(confidence)}
+      </span>
+    ),
+  }[confidence]);
+
+const allelicRequirementsCaption = allelicRequirements => {
+  const caption = allelicRequirements.split(' ', 1)[0].replace(/[;:,]*/g, '');
+  const description =
+    allelicRequirements
+      .split(' ')
+      .slice(1)
+      .join(' ') || 'No more information available';
+
+  return [caption, description];
+};
 
 const columns = [
   {
@@ -33,15 +68,47 @@ const columns = [
     renderCell: ({ diseaseFromSource }) => sentenceCase(diseaseFromSource),
   },
   {
-    id: 'allelicRequirement',
+    id: 'cohortPhenotypes',
+    renderCell: ({ cohortPhenotypes }) =>
+      cohortPhenotypes ? (
+        <List style={{ padding: 0 }}>
+          {cohortPhenotypes.map((entry, index) => (
+            <ListItem key={index} style={{ padding: '0 0 .5rem 0' }}>
+              {entry}
+            </ListItem>
+          ))}
+        </List>
+      ) : (
+        naLabel
+      ),
   },
   {
-    id: 'studyId',
+    id: 'allelicRequirements',
+    renderCell: ({ allelicRequirements }) =>
+      allelicRequirements
+        ? allelicRequirements.map((item, index) => {
+            const [caption, description] = allelicRequirementsCaption(item);
+
+            return (
+              <Tooltip
+                key={index}
+                placement="top"
+                interactive
+                title={description}
+              >
+                <span>{caption}</span>
+              </Tooltip>
+            );
+          })
+        : naLabel,
+  },
+  {
+    id: 'studyOverview',
     label: 'Genomics England Panel',
-    renderCell: ({ studyId, target: { approvedSymbol } }) =>
-      studyId && approvedSymbol ? (
+    renderCell: ({ studyOverview, studyId, target: { approvedSymbol } }) =>
+      studyOverview && studyId && approvedSymbol ? (
         <Link external to={geUrl(studyId, approvedSymbol)}>
-          {studyId}
+          {studyOverview}
         </Link>
       ) : (
         naLabel
@@ -49,10 +116,8 @@ const columns = [
   },
   {
     id: 'confidence',
-    numeric: true,
     sortable: true,
-    renderCell: ({ confidence }) =>
-      confidence ? parseFloat(confidence.toFixed(3)) : naLabel,
+    renderCell: ({ confidence }) => confidenceCaption(confidence),
   },
   {
     id: 'literature',

--- a/src/sections/evidence/GenomicsEngland/Body.js
+++ b/src/sections/evidence/GenomicsEngland/Body.js
@@ -43,7 +43,9 @@ const confidenceCaption = confidence =>
   }[confidence]);
 
 const allelicRequirementsCaption = allelicRequirements => {
-  const caption = allelicRequirements.split(' ', 1)[0].replace(/[;:,]*/g, '');
+  const caption = sentenceCase(
+    allelicRequirements.split(' ', 1)[0].replace(/[;:,]*/g, '')
+  );
   const description =
     allelicRequirements
       .split(' ')
@@ -95,8 +97,9 @@ const columns = [
                 placement="top"
                 interactive
                 title={description}
+                showHelpIcon
               >
-                <span>{caption}</span>
+                {caption}
               </Tooltip>
             );
           })

--- a/src/sections/evidence/GenomicsEngland/sectionQuery.gql
+++ b/src/sections/evidence/GenomicsEngland/sectionQuery.gql
@@ -15,6 +15,10 @@ query GenomicsEnglandQuery($ensemblId: String!, $efoId: String!) {
           approvedSymbol
         }
         diseaseFromSource
+        cohortPhenotypes
+        confidence
+        allelicRequirements
+        studyOverview
         studyId
         confidence
         literature

--- a/src/sections/evidence/IntOgen/Body.js
+++ b/src/sections/evidence/IntOgen/Body.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, makeStyles, Typography } from '@material-ui/core';
+import { Box, List, ListItem, makeStyles, Typography } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
@@ -14,8 +14,9 @@ import { epmcUrl } from '../../../utils/urls';
 import methods from './methods';
 import ScientificNotation from '../../../components/ScientificNotation';
 import SectionItem from '../../../components/Section/SectionItem';
-import usePlatformApi from '../../../hooks/usePlatformApi';
+import { sentenceCase } from '../../../utils/global';
 import Summary from './Summary';
+import usePlatformApi from '../../../hooks/usePlatformApi';
 
 const intOgenUrl = (id, approvedSymbol) =>
   `https://www.intogen.org/search?gene=${approvedSymbol}&cohort=${id}`;
@@ -31,20 +32,32 @@ const columns = [
     filterValue: ({ disease }) => disease.name,
   },
   {
-    id: 'numberMutatedSamples',
+    id: 'diseaseFromSource',
+    label: 'Reported Disease/phenotype',
+    renderCell: ({ diseaseFromSource }) =>
+      diseaseFromSource ? sentenceCase(diseaseFromSource) : naLabel,
+  },
+  {
+    id: 'mutatedSamples',
+    propertyPath: 'mutatedSamples.numberMutatedSamples',
     label: 'Mutated / Total samples',
-    propertyPath: 'variations.numberMutatedSamples',
     numeric: true,
-    renderCell: ({
-      variations: { 0: { numberMutatedSamples, numberSamplesTested } = {} },
-    }) =>
-      numberMutatedSamples && numberSamplesTested ? (
-        <>
-          {numberMutatedSamples}/{numberSamplesTested}
-        </>
-      ) : (
-        naLabel
-      ),
+    renderCell: ({ mutatedSamples }) => {
+      return (
+        <List style={{ padding: 0 }}>
+          {mutatedSamples.map(
+            ({ numberMutatedSamples, numberSamplesTested }, i) => (
+              <ListItem
+                key={i}
+                style={{ padding: '.25rem 0', justifyContent: 'flex-end' }}
+              >
+                {numberMutatedSamples}/{numberSamplesTested}
+              </ListItem>
+            )
+          )}
+        </List>
+      );
+    },
   },
   {
     id: 'resourceScore',

--- a/src/sections/evidence/IntOgen/sectionQuery.gql
+++ b/src/sections/evidence/IntOgen/sectionQuery.gql
@@ -12,13 +12,17 @@ query IntOgenQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
           id
           name
         }
+        diseaseFromSource
         target {
           approvedSymbol
         }
-        variations {
-          inheritancePattern
-          numberMutatedSamples
+        mutatedSamples {
+          functionalConsequence {
+            id
+            label
+          }
           numberSamplesTested
+          numberMutatedSamples
         }
         resourceScore
         significantDriverMethods

--- a/src/sections/evidence/OTGenetics/Body.js
+++ b/src/sections/evidence/OTGenetics/Body.js
@@ -114,10 +114,8 @@ const columns = [
     ),
     numeric: true,
     sortable: true,
-    renderCell: ({ resourceScore }) => (
-      <>
-        <ScientificNotation number={resourceScore} />
-      </>
+    renderCell: ({ pValueMantissa, pValueExponent }) => (
+      <ScientificNotation number={[pValueMantissa, pValueExponent]} />
     ),
   },
   {
@@ -147,7 +145,7 @@ const columns = [
     },
   },
   {
-    id: 'locus2GeneScore',
+    id: 'resourceScore',
     label: 'L2G score',
     tooltip: (
       <>
@@ -163,7 +161,7 @@ const columns = [
     ),
     numeric: true,
     sortable: true,
-    renderCell: ({ locus2GeneScore }) => parseFloat(locus2GeneScore.toFixed(5)),
+    renderCell: ({ resourceScore }) => parseFloat(resourceScore.toFixed(5)),
   },
 ];
 
@@ -194,7 +192,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
           pageSize={10}
           rowsPerPageOptions={defaultRowsPerPageOptions}
           showGlobalFilter
-          sortBy="locus2GeneScore"
+          sortBy="resourceScore"
         />
       )}
     />

--- a/src/sections/evidence/OTGenetics/sectionQuery.gql
+++ b/src/sections/evidence/OTGenetics/sectionQuery.gql
@@ -22,12 +22,11 @@ query OpenTargetsGeneticsQuery(
         studySampleSize
         variantId
         variantRsId
-        resourceScoreExponent
-        resourceScoreMantissa
-        locus2GeneScore
         literature
         publicationYear
         publicationFirstAuthor
+        pValueExponent
+        pValueMantissa
         oddsRatio
         confidenceIntervalLower
         confidenceIntervalUpper

--- a/src/sections/evidence/Phenodigm/Body.js
+++ b/src/sections/evidence/Phenodigm/Body.js
@@ -13,6 +13,7 @@ import Summary from './Summary';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 import { loader } from 'graphql.macro';
 import { List, ListItem, makeStyles } from '@material-ui/core';
+import { identifiersOrgLink } from '../../../utils/global';
 
 const useStyles = makeStyles({
   li: {
@@ -75,6 +76,18 @@ const columns = classes => [
     ),
     filterValue: ({ diseaseModelAssociatedModelPhenotypes = [] }) =>
       diseaseModelAssociatedModelPhenotypes.map(dmamp => dmamp.label).join(),
+  },
+  {
+    id: 'targetInModel',
+    label: 'Mouse gene',
+    renderCell: ({ targetInModel }) =>
+      targetInModel ? (
+        <Link external to={identifiersOrgLink('ensembl', targetInModel)}>
+          {targetInModel}
+        </Link>
+      ) : (
+        naLabel
+      ),
   },
   {
     id: 'literature',

--- a/src/sections/evidence/Phenodigm/sectionQuery.gql
+++ b/src/sections/evidence/Phenodigm/sectionQuery.gql
@@ -28,8 +28,7 @@ query IntOgenQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
           label
         }
         score
-        resourceScore
-        resourceScoreType
+        targetInModel
       }
     }
   }

--- a/src/sections/evidence/SlapEnrich/Body.js
+++ b/src/sections/evidence/SlapEnrich/Body.js
@@ -6,8 +6,9 @@ import { betaClient } from '../../../client';
 import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
-import SectionItem from '../../../components/Section/SectionItem';
 import ScientificNotation from '../../../components/ScientificNotation';
+import SectionItem from '../../../components/Section/SectionItem';
+import { sentenceCase } from '../../../utils/global';
 import Summary from './Summary';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 
@@ -28,6 +29,7 @@ const SLAPENRICH_QUERY = gql`
             id
             name
           }
+          diseaseFromSource
           pathwayId
           pathwayName
           resourceScore
@@ -45,6 +47,12 @@ const columns = [
       <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
     ),
     filterValue: ({ disease }) => disease.name,
+  },
+  {
+    id: 'diseaseFromSource',
+    label: 'Reported Disease/phenotype',
+    renderCell: ({ diseaseFromSource }) =>
+      diseaseFromSource ? sentenceCase(diseaseFromSource) : naLabel,
   },
   {
     id: 'pathwayName',

--- a/src/sections/evidence/SysBio/Body.js
+++ b/src/sections/evidence/SysBio/Body.js
@@ -55,7 +55,9 @@ const columns = [
     renderCell: ({ pathwayName, studyOverview }) =>
       pathwayName ? (
         studyOverview ? (
-          <Tooltip title={studyOverview}>{pathwayName}</Tooltip>
+          <Tooltip title={studyOverview} showHelpIcon>
+            {pathwayName}
+          </Tooltip>
         ) : (
           pathwayName
         )

--- a/src/sections/evidence/SysBio/Body.js
+++ b/src/sections/evidence/SysBio/Body.js
@@ -5,14 +5,13 @@ import { Link } from 'ot-ui';
 
 import { betaClient } from '../../../client';
 import { DataTable } from '../../../components/Table';
-import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
-import LongText from '../../../components/LongText';
+import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
+import { epmcUrl } from '../../../utils/urls';
 import SectionItem from '../../../components/Section/SectionItem';
 import Summary from './Summary';
+import Tooltip from '../../../components/Tooltip';
 import usePlatformApi from '../../../hooks/usePlatformApi';
-import { epmcUrl } from '../../../utils/urls';
-import { makeStyles } from '@material-ui/core';
 
 const INTOGEN_QUERY = gql`
   query IntOgenQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
@@ -29,15 +28,20 @@ const INTOGEN_QUERY = gql`
             id
             name
           }
-          literature
+          target {
+            id
+            approvedSymbol
+          }
           studyOverview
+          literature
+          pathwayName
         }
       }
     }
   }
 `;
 
-const columns = classes => [
+const columns = [
   {
     id: 'disease',
     renderCell: ({ disease }) => (
@@ -46,15 +50,18 @@ const columns = classes => [
     filterValue: ({ disease }) => disease.name,
   },
   {
-    id: 'studyOverview',
-    propertyPath: 'studyOverview',
-    renderCell: ({ studyOverview }) =>
-      studyOverview ? (
-        <LongText lineLimit={1}>{studyOverview}</LongText>
+    id: 'pathwayName',
+    label: 'Gene set',
+    renderCell: ({ pathwayName, studyOverview }) =>
+      pathwayName ? (
+        studyOverview ? (
+          <Tooltip title={studyOverview}>{pathwayName}</Tooltip>
+        ) : (
+          pathwayName
+        )
       ) : (
         naLabel
       ),
-    classes,
   },
   {
     id: 'literature',
@@ -69,10 +76,7 @@ const columns = classes => [
   },
 ];
 
-const useStyles = makeStyles({ cell: { whiteSpace: 'normal' } });
-
 function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const classes = useStyles();
   const {
     data: {
       sysBio: { count: size },
@@ -91,7 +95,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       renderDescription={() => <Description symbol={symbol} name={name} />}
       renderBody={data => (
         <DataTable
-          columns={columns(classes)}
+          columns={columns}
           dataDownloader
           dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
           rows={data.disease.evidences.rows}


### PR DESCRIPTION
Addresses the following issues with the 20.11 release for the evidence page:

* Gene2phenotype: https://github.com/opentargets/platform/issues/1228#issuecomment-737118285
* Open Targets Genetics: https://github.com/opentargets/platform/issues/1250#issuecomment-737103720
* Genomics England: https://github.com/opentargets/platform/issues/1234#issuecomment-737145059
* Cancer Gene Census: https://github.com/opentargets/platform/issues/1237#issuecomment-737183779
* IntOGen: https://github.com/opentargets/platform/issues/1238#issuecomment-737194180
* Phenodigm: https://github.com/opentargets/platform/issues/1242#issuecomment-737206970
* SLAPEnrich: https://github.com/opentargets/platform/issues/1235#issuecomment-737216332
* SysBio: https://github.com/opentargets/platform/issues/1239#issuecomment-737255304

---
Apart from that,

* Improved the `ScientificNotation` component so it accepts an array like `[mantissa, exponent]` as well as the usual JavaScript exponential notation number.
* Created a styled tooltip component that includes the default style decided in https://github.com/opentargets/platform/issues/1252
