### PR TITLE
Fixes to evidence sections layout and sorting

### DIFF
--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -69,7 +69,7 @@ function HeaderCell({
             </Tooltip>
           }
         >
-          {label}
+          <span className={headerClasses.headerLabelWithTooltip}>{label}</span>
         </Badge>
       ) : (
         label

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -32,6 +32,9 @@ export const tableStyles = makeStyles(theme => ({
     overflowX: 'auto',
     paddingRight: '.1rem', // fixes horizontal scrollbar
   },
+  headerLabelWithTooltip: {
+    lineHeight: '1.625rem',
+  },
   rowFixed: {
     backgroundColor: theme.palette.grey[300],
   },

--- a/src/sections/evidence/GenomicsEngland/Body.js
+++ b/src/sections/evidence/GenomicsEngland/Body.js
@@ -42,6 +42,12 @@ const confidenceCaption = confidence =>
     ),
   }[confidence]);
 
+const confidenceMap = confidence =>
+  ({
+    green: 20,
+    amber: 10,
+  }[confidence.toLowerCase()] || 0);
+
 const allelicRequirementsCaption = allelicRequirements => {
   const caption = sentenceCase(
     allelicRequirements.split(' ', 1)[0].replace(/[;:,]*/g, '')
@@ -121,6 +127,8 @@ const columns = [
     id: 'confidence',
     sortable: true,
     renderCell: ({ confidence }) => confidenceCaption(confidence),
+    comparator: (a, b) =>
+      confidenceMap(a.confidence) - confidenceMap(b.confidence),
   },
   {
     id: 'literature',
@@ -166,10 +174,12 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
           columns={columns}
           dataDownloader
           dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
+          order="desc"
           rows={data.disease.evidences.rows}
           pageSize={10}
           rowsPerPageOptions={defaultRowsPerPageOptions}
           showGlobalFilter
+          sortBy="confidence"
         />
       )}
     />

--- a/src/sections/evidence/IntOgen/Body.js
+++ b/src/sections/evidence/IntOgen/Body.js
@@ -190,7 +190,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
               columns={columns}
               dataDownloader
               dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
-              order="desc"
+              order="asc"
               rows={rows}
               sortBy="resourceScore"
               pageSize={10}

--- a/src/sections/evidence/IntOgen/Body.js
+++ b/src/sections/evidence/IntOgen/Body.js
@@ -62,10 +62,11 @@ const columns = [
   {
     id: 'resourceScore',
     label: (
-      <>
+      <span>
         Combined <i>p</i>-value
-      </>
+      </span>
     ),
+
     tooltip: (
       <>
         Visit the{' '}

--- a/src/sections/evidence/OTGenetics/Body.js
+++ b/src/sections/evidence/OTGenetics/Body.js
@@ -106,7 +106,7 @@ const columns = [
       }`,
   },
   {
-    id: 'resourceScore',
+    id: 'pValueMantissa',
     label: (
       <>
         Association <i>p</i>-value
@@ -117,6 +117,9 @@ const columns = [
     renderCell: ({ pValueMantissa, pValueExponent }) => (
       <ScientificNotation number={[pValueMantissa, pValueExponent]} />
     ),
+    comparator: (a, b) =>
+      a.pValueMantissa * 10 ** a.pValueExponent -
+      b.pValueMantissa * 10 ** b.pValueExponent,
   },
   {
     id: 'studySampleSize',


### PR DESCRIPTION
Addresses the following issues discussed in slack:

* Open Targets Genetics section is not sorting correctly.
* IntOGen section table header label `Combined p-value` has no space between `combined` and `p-value`.
* IntOGen section default ordering should be ascending, not descending.
* Genomics England section should allow sorting by confidence.
