### PR TITLE
20.11 Release - evidence page iteration 2

### DIFF
--- a/src/components/Table/DataTable.js
+++ b/src/components/Table/DataTable.js
@@ -26,6 +26,8 @@ function DataTable({
   const [globalFilterVal, setGlobalFilterVal] = useState('');
   const [sortColumn, setSortColumn] = useState(sortBy);
   const [sortOrder, setSortOrder] = useState(order);
+  const showPagination =
+    rows.length > [...rowsPerPageOptions, initialPageSize].sort()[0];
 
   const handleGlobalFilterChange = globalFilter => {
     setGlobalFilterVal(globalFilter);
@@ -84,6 +86,7 @@ function DataTable({
       onRowsPerPageChange={handleRowsPerPageChange}
       rowsPerPageOptions={rowsPerPageOptions}
       ActionsComponent={PaginationActionsComplete}
+      showPagination={showPagination}
     />
   );
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import {
+  CircularProgress,
   Grid,
   TableContainer,
   Table as MuiTable,
@@ -8,7 +9,6 @@ import {
   TableCell,
   TablePagination,
   TableRow as MUITableRow,
-  CircularProgress,
 } from '@material-ui/core';
 
 import DataDownloader from './DataDownloader';
@@ -40,6 +40,7 @@ const Table = ({
   noWrap = true,
   noWrapHeader = true,
   showGlobalFilter,
+  showPagination = true,
   globalFilter,
   rowsPerPageOptions = [],
   ActionsComponent,
@@ -134,20 +135,22 @@ const Table = ({
         {loading && (
           <CircularProgress className={defaultClasses.progress} size={22} />
         )}
-        <TablePagination
-          ActionsComponent={ActionsComponent}
-          backIconButtonProps={{ disabled: loading || page === 0 }}
-          nextIconButtonProps={{
-            disabled: loading || page >= rowCount / pageSize - 1,
-          }}
-          component="div"
-          count={rowCount}
-          onChangePage={handleChangePage}
-          onChangeRowsPerPage={handleChangeRowsPerPage}
-          page={page}
-          rowsPerPage={pageSize}
-          rowsPerPageOptions={rowsPerPageOptions}
-        />
+        {showPagination && (
+          <TablePagination
+            ActionsComponent={ActionsComponent}
+            backIconButtonProps={{ disabled: loading || page === 0 }}
+            nextIconButtonProps={{
+              disabled: loading || page >= rowCount / pageSize - 1,
+            }}
+            component="div"
+            count={rowCount}
+            onChangePage={handleChangePage}
+            onChangeRowsPerPage={handleChangeRowsPerPage}
+            page={page}
+            rowsPerPage={pageSize}
+            rowsPerPageOptions={rowsPerPageOptions}
+          />
+        )}
       </Grid>
     </Grid>
   );

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -9,6 +9,7 @@ import {
   TableCell,
   TablePagination,
   TableRow as MUITableRow,
+  Box,
 } from '@material-ui/core';
 
 import DataDownloader from './DataDownloader';
@@ -135,7 +136,7 @@ const Table = ({
         {loading && (
           <CircularProgress className={defaultClasses.progress} size={22} />
         )}
-        {showPagination && (
+        {showPagination ? (
           <TablePagination
             ActionsComponent={ActionsComponent}
             backIconButtonProps={{ disabled: loading || page === 0 }}
@@ -150,6 +151,8 @@ const Table = ({
             rowsPerPage={pageSize}
             rowsPerPageOptions={rowsPerPageOptions}
           />
+        ) : (
+          <Box className={defaultClasses.paginationPlaceholder} />
         )}
       </Grid>
     </Grid>

--- a/src/components/Table/TableDrawer.js
+++ b/src/components/Table/TableDrawer.js
@@ -69,7 +69,12 @@ const sourceDrawerStyles = makeStyles(theme => ({
   },
 }));
 
-function TableDrawer({ entries, message, caption = 'Records' }) {
+function TableDrawer({
+  entries,
+  message,
+  caption = 'Records',
+  showSingle = true,
+}) {
   const [open, setOpen] = useState(false);
   const classes = sourceDrawerStyles();
 
@@ -77,13 +82,13 @@ function TableDrawer({ entries, message, caption = 'Records' }) {
     return naLabel;
   }
 
-  if (entries.length === 1) {
+  if (entries.length === 1 && showSingle) {
     return entries[0].url ? (
       <Link external to={entries[0].url}>
         {entries[0].name}
       </Link>
     ) : (
-      entries[0].name
+      naLabel
     );
   }
 

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -2,22 +2,17 @@ import React from 'react';
 import classNames from 'classnames';
 import _ from 'lodash';
 import {
-  Badge,
-  Card,
-  CardContent,
-  makeStyles,
   Hidden,
   TableHead,
   TableRow,
   TableCell,
   TableSortLabel,
-  Tooltip,
   withWidth,
 } from '@material-ui/core';
-import HelpIcon from '@material-ui/icons/Help';
 
-import { tableStyles } from './tableStyles';
 import { getHiddenBreakpoints } from './utils';
+import { tableStyles } from './tableStyles';
+import Tooltip from '../Tooltip';
 import useDynamicColspan from '../../hooks/useDynamicColspans';
 
 function HeaderCell({
@@ -34,13 +29,9 @@ function HeaderCell({
   sticky = false,
   tooltip,
   tooltipStyle = {},
-  TooltipIcon = HelpIcon,
   width,
 }) {
   const headerClasses = tableStyles();
-  const tooltipClasses = makeStyles(
-    _.merge(tooltipStyle, { tooltip: { padding: 0 } })
-  )();
 
   const style = {
     minWidth,
@@ -49,28 +40,11 @@ function HeaderCell({
   };
 
   const labelInnerComponent = (
-    <span className={classes.innerLabel}>
+    <span className={classNames(classes.innerLabel, headerClasses.headerSpan)}>
       {tooltip ? (
-        <Badge
-          badgeContent={
-            <Tooltip
-              interactive
-              placement="top"
-              classes={tooltipClasses}
-              title={
-                <Card elevation={0}>
-                  <CardContent className={headerClasses.tooltipCardContent}>
-                    {tooltip}
-                  </CardContent>
-                </Card>
-              }
-            >
-              <TooltipIcon className={headerClasses.tooltipIcon} />
-            </Tooltip>
-          }
-        >
+        <Tooltip style={tooltipStyle} showHelpIcon title={tooltip}>
           <span className={headerClasses.headerLabelWithTooltip}>{label}</span>
-        </Badge>
+        </Tooltip>
       ) : (
         label
       )}

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -75,6 +75,9 @@ export const tableStyles = makeStyles(theme => ({
       padding: '.5rem',
     },
   },
+  paginationPlaceholder: {
+    height: '36px',
+  },
   progress: {
     position: 'relative',
     top: '6px',

--- a/src/components/Table/tableStyles.js
+++ b/src/components/Table/tableStyles.js
@@ -66,10 +66,6 @@ export const tableStyles = makeStyles(theme => ({
   tabularNums: {
     fontVariant: 'tabular-nums',
   },
-  tooltipIcon: {
-    fontSize: '1.5rem',
-    paddingLeft: `0.6rem`,
-  },
   tooltipCardContent: {
     '&:last-child': {
       padding: '.5rem',

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,21 +1,25 @@
 import React from 'react';
-import { Help } from '@material-ui/icons';
 import { makeStyles, Tooltip as MUITooltip } from '@material-ui/core';
+import _ from 'lodash';
 
-const useStyles = makeStyles(theme => ({
-  tooltip: {
-    backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.grey[300]}`,
-    color: theme.palette.text.primary,
-  },
-  tooltipIcon: {
-    fontSize: '.75rem',
-    marginBottom: '.2rem',
-  },
-}));
-
-function Tooltip({ children, title, showHelpIcon = false, ...props }) {
-  const classes = useStyles();
+function Tooltip({ style, children, title, showHelpIcon = false, ...props }) {
+  const classes = makeStyles(theme =>
+    _.merge(style, {
+      tooltip: {
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.grey[300]}`,
+        color: theme.palette.text.primary,
+      },
+      tooltipBadge: {
+        paddingLeft: '1rem',
+        top: '.4rem',
+      },
+      tooltipIcon: {
+        fontWeight: '500',
+        cursor: 'default',
+      },
+    })
+  )();
 
   return (
     <>
@@ -27,7 +31,7 @@ function Tooltip({ children, title, showHelpIcon = false, ...props }) {
         title={title}
         {...props}
       >
-        {showHelpIcon ? <Help className={classes.tooltipIcon} /> : children}
+        {showHelpIcon ? <sup className={classes.tooltipIcon}>?</sup> : children}
       </MUITooltip>
     </>
   );

--- a/src/sections/evidence/GenomicsEngland/Body.js
+++ b/src/sections/evidence/GenomicsEngland/Body.js
@@ -6,7 +6,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { loader } from 'graphql.macro';
-import { List, ListItem } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 
 import { Link } from 'ot-ui';
 
@@ -18,8 +18,8 @@ import { epmcUrl } from '../../../utils/urls';
 import { sentenceCase } from '../../../utils/global';
 import SectionItem from '../../../components/Section/SectionItem';
 import Summary from './Summary';
-import usePlatformApi from '../../../hooks/usePlatformApi';
 import Tooltip from '../../../components/Tooltip';
+import usePlatformApi from '../../../hooks/usePlatformApi';
 
 const geUrl = (id, approvedSymbol) =>
   `https://panelapp.genomicsengland.co.uk/panels/${id}/gene/${approvedSymbol}`;
@@ -65,33 +65,46 @@ const columns = [
   {
     id: 'disease',
     label: 'Disease/phenotype',
-    renderCell: ({ disease }) => (
-      <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+    renderCell: ({ disease, diseaseFromSource }) => (
+      <Tooltip
+        showHelpIcon
+        title={
+          <>
+            <Typography variant="subtitle2">
+              Reported Disease/phenotype:
+            </Typography>
+            <Typography variant="caption">{diseaseFromSource}</Typography>
+          </>
+        }
+      >
+        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      </Tooltip>
     ),
-    filterValue: ({ disease }) => disease.name,
-  },
-  {
-    id: 'diseaseFromSource',
-    label: 'Reported Disease/phenotype',
-    renderCell: ({ diseaseFromSource }) => sentenceCase(diseaseFromSource),
+    filterValue: ({ disease, diseaseFromSource }) =>
+      [disease.name, diseaseFromSource].join(),
   },
   {
     id: 'cohortPhenotypes',
+    label: 'All phenotypes',
     renderCell: ({ cohortPhenotypes }) =>
       cohortPhenotypes ? (
-        <List style={{ padding: 0 }}>
-          {cohortPhenotypes.map((entry, index) => (
-            <ListItem key={index} style={{ padding: '.25rem 0' }}>
-              {entry}
-            </ListItem>
-          ))}
-        </List>
+        <TableDrawer
+          entries={cohortPhenotypes.map(item => ({
+            name: item,
+            group: 'Reported phenotypes',
+          }))}
+          showSingle={false}
+          message={`${cohortPhenotypes.length} phenotype${
+            cohortPhenotypes.length !== 1 ? 's' : ''
+          }`}
+        />
       ) : (
         naLabel
       ),
   },
   {
     id: 'allelicRequirements',
+    label: 'Allelic Requirement',
     renderCell: ({ allelicRequirements }) =>
       allelicRequirements
         ? allelicRequirements.map((item, index) => {

--- a/src/sections/evidence/Progeny/Body.js
+++ b/src/sections/evidence/Progeny/Body.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { gql, useQuery } from '@apollo/client';
+import { Typography } from '@material-ui/core';
+
 import { Link } from 'ot-ui';
 
 import { betaClient } from '../../../client';
@@ -9,6 +11,7 @@ import Description from './Description';
 import SectionItem from '../../../components/Section/SectionItem';
 import ScientificNotation from '../../../components/ScientificNotation';
 import Summary from './Summary';
+import Tooltip from '../../../components/Tooltip';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 
 const reactomeUrl = id => `http://www.reactome.org/PathwayBrowser/#${id}`;
@@ -28,6 +31,7 @@ const PROGENY_QUERY = gql`
             id
             name
           }
+          diseaseFromSource
           pathwayId
           pathwayName
           resourceScore
@@ -41,10 +45,23 @@ const columns = [
   {
     id: 'disease',
     label: 'Disease/phenotype',
-    renderCell: ({ disease }) => (
-      <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+    renderCell: ({ disease, diseaseFromSource }) => (
+      <Tooltip
+        showHelpIcon
+        title={
+          <>
+            <Typography variant="subtitle2">
+              Reported Disease/phenotype:
+            </Typography>
+            <Typography variant="caption">{diseaseFromSource}</Typography>
+          </>
+        }
+      >
+        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      </Tooltip>
     ),
-    filterValue: ({ disease }) => disease.name,
+    filterValue: ({ disease, diseaseFromSource }) =>
+      [disease.name, diseaseFromSource].join(),
   },
   {
     id: 'pathwayName',

--- a/src/sections/evidence/SlapEnrich/Body.js
+++ b/src/sections/evidence/SlapEnrich/Body.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { gql, useQuery } from '@apollo/client';
+import { Typography } from '@material-ui/core';
+
 import { Link } from 'ot-ui';
 
 import { betaClient } from '../../../client';
@@ -8,8 +10,8 @@ import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
 import ScientificNotation from '../../../components/ScientificNotation';
 import SectionItem from '../../../components/Section/SectionItem';
-import { sentenceCase } from '../../../utils/global';
 import Summary from './Summary';
+import Tooltip from '../../../components/Tooltip';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 
 const reactomeUrl = id => `http://www.reactome.org/PathwayBrowser/#${id}`;
@@ -43,16 +45,23 @@ const columns = [
   {
     id: 'disease',
     label: 'Disease/phenotype',
-    renderCell: ({ disease }) => (
-      <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+    renderCell: ({ disease, diseaseFromSource }) => (
+      <Tooltip
+        showHelpIcon
+        title={
+          <>
+            <Typography variant="subtitle2">
+              Reported Disease/phenotype:
+            </Typography>
+            <Typography variant="caption">{diseaseFromSource}</Typography>
+          </>
+        }
+      >
+        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      </Tooltip>
     ),
-    filterValue: ({ disease }) => disease.name,
-  },
-  {
-    id: 'diseaseFromSource',
-    label: 'Reported Disease/phenotype',
-    renderCell: ({ diseaseFromSource }) =>
-      diseaseFromSource ? sentenceCase(diseaseFromSource) : naLabel,
+    filterValue: ({ disease, diseaseFromSource }) =>
+      [disease.name, diseaseFromSource].join(),
   },
   {
     id: 'pathwayName',

--- a/src/sections/evidence/SysBio/Body.js
+++ b/src/sections/evidence/SysBio/Body.js
@@ -44,6 +44,7 @@ const INTOGEN_QUERY = gql`
 const columns = [
   {
     id: 'disease',
+    label: 'Disease/phenotype',
     renderCell: ({ disease }) => (
       <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
     ),

--- a/src/sections/target/CancerHallmarks/Body.js
+++ b/src/sections/target/CancerHallmarks/Body.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import { Box, makeStyles, Typography } from '@material-ui/core';
 
 import { Link } from 'ot-ui';
 
@@ -8,6 +8,7 @@ import SectionItem from '../../../components/Section/SectionItem';
 import Summary from './Summary';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 import Description from './Description';
+import ChipList from '../../../components/ChipList';
 
 const columns = [
   {
@@ -44,7 +45,17 @@ const columns = [
   },
 ];
 
+const useStyles = makeStyles({
+  roleInCancerBox: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: '2rem',
+  },
+  roleInCancerTitle: { marginRight: '.5rem' },
+});
+
 function Section({ definition, id: ensgId, label: symbol }) {
+  const classes = useStyles();
   const request = usePlatformApi(
     Summary.fragments.CancerHallmarksSummaryFragment
   );
@@ -55,9 +66,14 @@ function Section({ definition, id: ensgId, label: symbol }) {
       request={request}
       renderDescription={() => <Description symbol={symbol} />}
       renderBody={data => {
-        const roleInCancer = data.hallmarks.attributes.filter(
-          a => a.name === 'role in cancer'
-        );
+        const roleInCancer = data.hallmarks.attributes
+          .filter(a => a.name === 'role in cancer')
+          .map(r => ({
+            label: r.reference.description,
+            url: `http://europepmc.org/search?query=EXT_ID:${
+              r.reference.pubmedId
+            }`,
+          }));
         const rows = data.hallmarks.rows.map(r => ({
           label: r.label,
           activity: r.promote ? 'promotes' : r.suppress ? 'suppresses' : '',
@@ -67,22 +83,18 @@ function Section({ definition, id: ensgId, label: symbol }) {
 
         return (
           <>
-            <Typography variant="body2">
-              Role in cancer:{' '}
-              {roleInCancer.map((r, i) => (
-                <React.Fragment key={i}>
-                  {i > 0 ? ' | ' : null}
-                  <Link
-                    external
-                    to={`http://europepmc.org/search?query=EXT_ID:${
-                      r.reference.pubmedId
-                    }`}
-                  >
-                    {r.reference.description}
-                  </Link>
-                </React.Fragment>
-              )) || 'No data'}
-            </Typography>
+            <Box className={classes.roleInCancerBox}>
+              <Typography className={classes.roleInCancerTitle}>
+                Role in cancer:
+              </Typography>
+              <ChipList
+                items={
+                  roleInCancer.length > 0
+                    ? roleInCancer
+                    : [{ label: 'Unknown' }]
+                }
+              />
+            </Box>
             <DataTable
               columns={columns}
               dataDownloader


### PR DESCRIPTION
Addresses the following Evidence Page sections: 

* Genomics England: https://github.com/opentargets/platform/issues/1234#issuecomment-740001124
* Cancer Gene Census: https://github.com/opentargets/platform/issues/1237#issuecomment-740219137
* IntOGen: https://github.com/opentargets/platform/issues/1238#issuecomment-740029942
* PROGENy: https://github.com/opentargets/platform/issues/1236#issuecomment-740197958
* SLAPenrich: https://github.com/opentargets/platform/issues/1235#issuecomment-740198341
* SysBio: https://github.com/opentargets/platform/issues/1239#issuecomment-740208904
* Phenodigm: https://github.com/opentargets/platform/issues/1242#issuecomment-741090278

---

Also added the following changes, discussed with @d0choa and @andrewhercules in meetings:

* Pagination buttons, page indicator and page size selector are now hidden if not needed (if the smallest page size possible in the drop-down is bigger than the total amount of rows). This only works in tables that are handled in the client.
* The table `TableDrawer` component now accepts a parameter that decides whether to show a single element in the table or still pop up a drawer.
* Tooltip indicator has been made less intrusive.
