### PR TITLE
Stop using activity field in known drugs / clinical precedence widgets

### DIFF
--- a/src/sections/common/KnownDrugs/Body.js
+++ b/src/sections/common/KnownDrugs/Body.js
@@ -56,9 +56,25 @@ const columnPool = {
         id: 'mechanismOfAction',
       },
       {
-        id: 'activity',
-        hidden: ['lgDown'],
-        renderCell: d => (d.activity ? d.activity : naLabel),
+        id: 'Action types',
+        renderCell: ({ drug: { mechanismsOfAction } }) => {
+          const uniqueActionTypes = mechanismsOfAction.uniqueActionTypes || [];
+          return uniqueActionTypes.length > 0 ? (
+            <ul
+              style={{
+                margin: 0,
+                padding: 0,
+                listStyle: 'none',
+              }}
+            >
+              {uniqueActionTypes.map(actionType => (
+                <li key={actionType}>{actionType}</li>
+              ))}
+            </ul>
+          ) : (
+            naLabel
+          );
+        },
       },
     ],
   },

--- a/src/sections/disease/KnownDrugs/Body.js
+++ b/src/sections/disease/KnownDrugs/Body.js
@@ -30,10 +30,12 @@ const KNOWN_DRUGS_BODY_QUERY = gql`
           drug {
             id
             name
+            mechanismsOfAction {
+              uniqueActionTypes
+            }
           }
           drugType
           mechanismOfAction
-          activity
           target {
             id
             approvedName

--- a/src/sections/target/KnownDrugs/Body.js
+++ b/src/sections/target/KnownDrugs/Body.js
@@ -30,10 +30,12 @@ const KNOWN_DRUGS_BODY_QUERY = gql`
           drug {
             id
             name
+            mechanismsOfAction {
+              uniqueActionTypes
+            }
           }
           drugType
           mechanismOfAction
-          activity
         }
       }
     }


### PR DESCRIPTION
Closes https://github.com/opentargets/platform/issues/1143 and https://github.com/opentargets/platform/issues/1143