### PR TITLE
Remove related targets/disease from profile pages

### DIFF
--- a/src/pages/DiseasePage/sections.js
+++ b/src/pages/DiseasePage/sections.js
@@ -3,12 +3,12 @@ import * as Bibliography from '../../sections/common/Bibliography';
 import * as KnownDrugs from '../../sections/disease/KnownDrugs';
 import * as Ontology from '../../sections/disease/Ontology';
 import * as Phenotypes from '../../sections/disease/Phenotypes';
-import * as RelatedDiseases from '../../sections/disease/RelatedDiseases';
+// import * as RelatedDiseases from '../../sections/disease/RelatedDiseases';
 
 export default [
   Ontology,
   KnownDrugs,
   Phenotypes,
-  RelatedDiseases,
+  // RelatedDiseases,
   Bibliography,
 ];

--- a/src/pages/TargetPage/sections.js
+++ b/src/pages/TargetPage/sections.js
@@ -10,8 +10,7 @@ import * as KnownDrugs from '../../sections/target/KnownDrugs';
 import * as MousePhenotypes from '../../sections/target/MousePhenotypes';
 import * as Pathways from '../../sections/target/Pathways';
 import * as ProteinInformation from '../../sections/target/ProteinInformation';
-// import * as ProteinInteractions from '../../sections/target/ProteinInteractions';
-import * as RelatedTargets from '../../sections/target/RelatedTargets';
+// import * as RelatedTargets from '../../sections/target/RelatedTargets';
 import * as Safety from '../../sections/target/Safety';
 import * as Tep from '../../sections/target/Tep';
 import * as Tractability from '../../sections/target/Tractability';
@@ -27,7 +26,7 @@ export default [
   GeneOntology,
   ProteinInformation,
   Pathways,
-  RelatedTargets,
+  // RelatedTargets,
   CancerBiomarkers,
   CancerHallmarks,
   MousePhenotypes,


### PR DESCRIPTION
This PR removes the related targets/disease widgets from the profile pages.
Closes opentargets/platform#1301