### PR TITLE
Fix disease page crashing

### DIFF
--- a/src/components/Section/SectionItem.js
+++ b/src/components/Section/SectionItem.js
@@ -79,7 +79,7 @@ function SectionItem({
               <Box className={classes.loadingPlaceholder} />
             )}
             {error && <SectionError error={error} />}
-            {data && (
+            {!loading && data && (
               <CardContent className={classes.cardContent}>
                 {renderBody(data)}
               </CardContent>


### PR DESCRIPTION
Addresses the issue in https://github.com/opentargets/platform/issues/1302

The disease page was crashing due to a race condition introduced by the driver rework. This PR fixes that race condition.