### PR TITLE
Lf evid textupdates

### DIFF
--- a/src/pages/EvidencePage/Header.js
+++ b/src/pages/EvidencePage/Header.js
@@ -9,7 +9,6 @@ function EvidenceHeader({ loading, symbol, name }) {
       loading={loading}
       title={`Evidence for ${symbol} in ${name}`}
       Icon={faProjectDiagram}
-      externalLinks="There should be some links here!"
     />
   );
 }

--- a/src/sections/evidence/CRISPR/Summary.js
+++ b/src/sections/evidence/CRISPR/Summary.js
@@ -22,7 +22,10 @@ function Summary({ definition }) {
     <SummaryItem
       definition={definition}
       request={request}
-      renderSummary={() => 'CRISPR screen prioritised'}
+      renderSummary={({ crisprSummary }) => {
+        const { count } = crisprSummary;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
+      }}
     />
   );
 }

--- a/src/sections/evidence/CancerGeneCensus/Summary.js
+++ b/src/sections/evidence/CancerGeneCensus/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ cancerGeneCensusSummary }) => {
         const { count } = cancerGeneCensusSummary;
-        return count > 0 ? 'known mutations' : null;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/Chembl/Summary.js
+++ b/src/sections/evidence/Chembl/Summary.js
@@ -25,7 +25,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ chemblSummary }) => {
         const { count } = chemblSummary;
-        return `${count} record${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/ClinGen/Summary.js
+++ b/src/sections/evidence/ClinGen/Summary.js
@@ -25,7 +25,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ clingenSummary }) => {
         const { count } = clingenSummary;
-        return `${count} record${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/EVA/Summary.js
+++ b/src/sections/evidence/EVA/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ evaSummary }) => {
         const { count } = evaSummary;
-        return `${count} variant${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/EVASomatic/Summary.js
+++ b/src/sections/evidence/EVASomatic/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ evaSomaticSummary }) => {
         const { count } = evaSomaticSummary;
-        return `${count} variant${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/ExpressionAtlas/Summary.js
+++ b/src/sections/evidence/ExpressionAtlas/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ expressionAtlasSummary }) => {
         const { count } = expressionAtlasSummary;
-        return `${count} record${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/PheWASCatalog/Summary.js
+++ b/src/sections/evidence/PheWASCatalog/Summary.js
@@ -24,7 +24,10 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ phewasCatalogSummary }) => {
         const { count } = phewasCatalogSummary;
-        return `${count} variant${count > 1 ? 's' : ''}`;
+        {
+          /* return `${count} variant${count > 1 ? 's' : ''}`; */
+        }
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/PheWASCatalog/Summary.js
+++ b/src/sections/evidence/PheWASCatalog/Summary.js
@@ -24,9 +24,6 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ phewasCatalogSummary }) => {
         const { count } = phewasCatalogSummary;
-        {
-          /* return `${count} variant${count > 1 ? 's' : ''}`; */
-        }
         return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />

--- a/src/sections/evidence/Reactome/Summary.js
+++ b/src/sections/evidence/Reactome/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ reactomeSummary }) => {
         const { count } = reactomeSummary;
-        return `${count} pathway${count > 1 ? 's' : ''}`;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );

--- a/src/sections/evidence/UniProtLiterature/Summary.js
+++ b/src/sections/evidence/UniProtLiterature/Summary.js
@@ -24,7 +24,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={({ uniprotLiteratureSummary }) => {
         const { count } = uniprotLiteratureSummary;
-        return count > 0 ? 'known variants' : null;
+        return `${count} ${count === 1 ? 'entry' : 'entries'}`;
       }}
     />
   );


### PR DESCRIPTION
Short PR to cleanup text in the evidence page:
 - removes placeholder links text below page main header (issue 1271)
 - updates all required summary widgets text to "n entries" (issue 1270)