### PR TITLE
Lf target synonyms

### DIFF
--- a/src/pages/EvidencePage/ProfileHeader.js
+++ b/src/pages/EvidencePage/ProfileHeader.js
@@ -28,6 +28,7 @@ const EVIDENCE_PROFILE_TARGET_HEADER_FRAGMENT = gql`
       functions
     }
     symbolSynonyms
+    nameSynonyms
   }
 `;
 const EVIDENCE_PROFILE_DISEASE_HEADER_FRAGMENT = gql`
@@ -60,8 +61,11 @@ function ProfileHeader() {
     synonyms: diseaseSynonyms,
   } = data?.disease || {};
   const targetDescription = data?.target.proteinAnnotations?.functions?.[0];
-  const { id: ensgId, approvedSymbol, symbolSynonyms: targetSynonyms } =
-    data?.target || {};
+
+  const { id: ensgId, approvedSymbol } = data?.target || {};
+  const targetSynonyms = data?.target.symbolSynonyms.concat(
+    data?.target.nameSynonyms
+  );
 
   return (
     <BaseProfileHeader>

--- a/src/pages/TargetPage/ProfileHeader.js
+++ b/src/pages/TargetPage/ProfileHeader.js
@@ -15,6 +15,7 @@ const TARGET_PROFILE_HEADER_FRAGMENT = gql`
       functions
     }
     symbolSynonyms
+    nameSynonyms
   }
 `;
 
@@ -25,7 +26,9 @@ function ProfileHeader() {
   if (error) return null;
 
   const description = data?.target.proteinAnnotations?.functions?.[0];
-  const synonyms = data?.target.symbolSynonyms;
+  const synonyms = data?.target.symbolSynonyms.concat(
+    data?.target.nameSynonyms
+  );
 
   return (
     <BaseProfileHeader>


### PR DESCRIPTION
Short PR to fix missing synonyms for certain targets in profile and evidence page (issues 1216).
It concatenates fields symbolSynonyms and nameSynonyms (the former could be empty).