### PR TITLE
Fix broken external links in chemical probes widget

### DIFF
--- a/src/sections/target/ChemicalProbes/Body.js
+++ b/src/sections/target/ChemicalProbes/Body.js
@@ -19,7 +19,10 @@ const columns = [
     renderCell: rowData =>
       rowData.sourcelinks.map((d, i, a) => (
         <React.Fragment key={i}>
-          <Link external to={d.link}>
+          <Link
+            external
+            to={`${!d.link.startsWith('http') ? 'http://' : ''}${d.link}`}
+          >
             {d.source}
           </Link>
           {i < a.length - 1 ? ' / ' : ''}


### PR DESCRIPTION
Very short PR. This fixes the broken external in the Chemical probes widget on target profile page.
It appears that certain links are missing the "http..." (this is missing in the data) and therefore the external link fails. 
This is the case also for the Angular app and we take a similar approach.

Fixes issue https://github.com/opentargets/platform/issues/1184