### PR TITLE
Lf phenotypes improvements

### DIFF
--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -85,15 +85,23 @@ const columns = [
   {
     id: 'phenotypeHPO',
     label: 'Phenotype',
-    renderCell: ({ phenotypeEFO, phenotypeHPO }) => (
-      <Tooltip title={`Description: ${phenotypeHPO.description}`} showHelpIcon>
-        {phenotypeEFO?.id ? (
-          <Link to={`/disease/${phenotypeEFO.id}`}>{phenotypeHPO.name}</Link>
-        ) : (
-          phenotypeHPO.name
-        )}
-      </Tooltip>
-    ),
+    renderCell: ({ phenotypeEFO, phenotypeHPO }) => {
+      const content = phenotypeEFO?.id ? (
+        <Link to={`/disease/${phenotypeEFO.id}`}>{phenotypeHPO.name}</Link>
+      ) : (
+        <>{phenotypeHPO.name || naLabel}</>
+      );
+      return phenotypeHPO.description ? (
+        <Tooltip
+          title={`Description: ${phenotypeHPO.description}`}
+          showHelpIcon
+        >
+          {content}
+        </Tooltip>
+      ) : (
+        <>{content}</>
+      );
+    },
     filterValue: row => row.phenotypeHPO.name,
     exportValue: row => row.phenotypeHPO.name,
     // width: '9%',

--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -78,9 +78,9 @@ const columns = [
     label: 'Qualifier',
     exportLabel: 'qualifierNot',
     renderCell: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
+    filterValue: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
     // exportValue: d => d.url,
     // width: '7%',
-    // filterValue: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
   },
   {
     id: 'phenotypeHPO',
@@ -94,8 +94,8 @@ const columns = [
         )}
       </Tooltip>
     ),
+    filterValue: row => row.phenotypeHPO.name,
     // width: '9%',
-    // filterValue: row => row.phenotypeHPO.name,
   },
   {
     id: 'phenotypeHDOid',
@@ -108,8 +108,8 @@ const columns = [
         </Link>
       );
     },
+    filterValue: row => row.phenotypeHPO.id,
     // width: '9%',
-    // filterValue: row => row.phenotypeHPO.id,
   },
   {
     id: 'aspect',
@@ -124,6 +124,7 @@ const columns = [
         {evidence.aspect}
       </Tooltip>
     ),
+    filterValue: row => row.evidence.aspect,
     // width: '7%',
   },
   {
@@ -147,6 +148,7 @@ const columns = [
       ) : (
         naLabel
       ),
+    filterValue: row => row.evidence.frequencyHPO?.name || naLabel,
     // width: '9%',
   },
   {
@@ -166,6 +168,7 @@ const columns = [
             </span>
           ))
         : naLabel,
+    filterValue: row => row.evidence.onset?.map(o => o.name).join() || naLabel,
     // width: '9%',
   },
   {
@@ -185,12 +188,15 @@ const columns = [
             </span>
           ))
         : naLabel,
+    filterValue: row =>
+      row.evidence.modifiers?.map(m => m.name).join() || naLabel,
     // width: '9%',
   },
   {
     id: 'sex',
     label: 'Sex',
     renderCell: ({ evidence }) => _.capitalize(evidence.sex) || naLabel,
+    filterValue: row => row.evidence.sex || naLabel,
     // width: '9%',
   },
   {
@@ -207,12 +213,14 @@ const columns = [
       ) : (
         naLabel
       ),
+    filterValue: row => row.evidence.evidenceType || naLabel,
     // width: '7%',
   },
   {
     id: 'source',
     label: 'Source',
     renderCell: ({ evidence }) => evidence.resource || naLabel,
+    filterValue: row => row.evidence.resource || naLabel,
     // width: '9%',
   },
   {
@@ -236,6 +244,7 @@ const columns = [
             );
           })
         : naLabel,
+    filterValue: row => row.evidence.references?.map(r => r).join() || naLabel,
     // width: '9%',
   },
 ];

--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -3,7 +3,7 @@ import { gql, useQuery } from '@apollo/client';
 import _ from 'lodash';
 
 import Description from './Description';
-import { DataTable } from '../../../components/Table';
+import { DataTable, TableDrawer } from '../../../components/Table';
 import Link from '../../../components/Link';
 import SectionItem from '../../../components/Section/SectionItem';
 import Tooltip from '../../../components/Tooltip';
@@ -235,24 +235,21 @@ const columns = [
   {
     id: 'references',
     label: 'References',
-    renderCell: ({ evidence }) =>
-      evidence.references?.length > 0
-        ? evidence.references.map((r, i) => {
-            const url = r.toUpperCase().startsWith('PMID:')
-              ? `https://europepmc.org/search?query=EXT_ID:${r
-                  .split(':')
-                  .pop()}`
-              : `https://hpo.jax.org/app/browse/disease/${r}`;
-            return (
-              <span key={i}>
-                <Link external to={url}>
-                  {r}
-                </Link>
-                <br />
-              </span>
-            );
-          })
-        : naLabel,
+    renderCell: ({ evidence }) => {
+      // no references
+      if (!evidence.references || evidence.references.length === 0) {
+        return naLabel;
+      }
+      // parse references
+      const refs = evidence.references.map(r => ({
+        url: r.toUpperCase().startsWith('PMID:')
+          ? `https://europepmc.org/search?query=EXT_ID:${r.split(':').pop()}`
+          : `https://hpo.jax.org/app/browse/disease/${r}`,
+        name: r,
+        group: 'References',
+      }));
+      return <TableDrawer entries={refs} />;
+    },
     filterValue: row => row.evidence.references?.map(r => r).join() || naLabel,
     exportValue: row => row.evidence.references?.map(r => r).join() || naLabel,
     // width: '9%',

--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -88,7 +88,7 @@ const columns = [
     renderCell: ({ phenotypeEFO, phenotypeHPO }) => (
       <Tooltip title={`Description: ${phenotypeHPO.description}`} showHelpIcon>
         {phenotypeEFO?.id ? (
-          <Link to={`disease/${phenotypeEFO.id}`}>{phenotypeHPO.name}</Link>
+          <Link to={`/disease/${phenotypeEFO.id}`}>{phenotypeHPO.name}</Link>
         ) : (
           phenotypeHPO.name
         )}

--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -79,7 +79,7 @@ const columns = [
     exportLabel: 'qualifierNot',
     renderCell: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
     filterValue: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
-    // exportValue: d => d.url,
+    exportValue: ({ evidence }) => (evidence.qualifierNot ? 'NOT' : ''),
     // width: '7%',
   },
   {
@@ -95,6 +95,7 @@ const columns = [
       </Tooltip>
     ),
     filterValue: row => row.phenotypeHPO.name,
+    exportValue: row => row.phenotypeHPO.name,
     // width: '9%',
   },
   {
@@ -108,7 +109,8 @@ const columns = [
         </Link>
       );
     },
-    filterValue: row => row.phenotypeHPO.id,
+    filterValue: row => row.phenotypeHPO.id.replace('_', ':'),
+    exportValue: row => row.phenotypeHPO.id.replace('_', ':'),
     // width: '9%',
   },
   {
@@ -125,6 +127,7 @@ const columns = [
       </Tooltip>
     ),
     filterValue: row => row.evidence.aspect,
+    exportValue: row => row.evidence.aspect,
     // width: '7%',
   },
   {
@@ -149,6 +152,7 @@ const columns = [
         naLabel
       ),
     filterValue: row => row.evidence.frequencyHPO?.name || naLabel,
+    exportValue: row => row.evidence.frequencyHPO?.name || naLabel,
     // width: '9%',
   },
   {
@@ -169,6 +173,7 @@ const columns = [
           ))
         : naLabel,
     filterValue: row => row.evidence.onset?.map(o => o.name).join() || naLabel,
+    exportValue: row => row.evidence.onset?.map(o => o.name).join() || naLabel,
     // width: '9%',
   },
   {
@@ -189,6 +194,8 @@ const columns = [
           ))
         : naLabel,
     filterValue: row =>
+      row.evidence.modifiers?.map(m => m.name).join() || naLabel,
+    exportValue: row =>
       row.evidence.modifiers?.map(m => m.name).join() || naLabel,
     // width: '9%',
   },
@@ -214,6 +221,7 @@ const columns = [
         naLabel
       ),
     filterValue: row => row.evidence.evidenceType || naLabel,
+    exportValue: row => row.evidence.evidenceType || naLabel,
     // width: '7%',
   },
   {
@@ -221,6 +229,7 @@ const columns = [
     label: 'Source',
     renderCell: ({ evidence }) => evidence.resource || naLabel,
     filterValue: row => row.evidence.resource || naLabel,
+    exportValue: row => row.evidence.resource || naLabel,
     // width: '9%',
   },
   {
@@ -245,6 +254,7 @@ const columns = [
           })
         : naLabel,
     filterValue: row => row.evidence.references?.map(r => r).join() || naLabel,
+    exportValue: row => row.evidence.references?.map(r => r).join() || naLabel,
     // width: '9%',
   },
 ];
@@ -258,30 +268,12 @@ function Body({ definition, label: name, id: efoId }) {
     },
   });
 
-  // return (
-  //   <SectionItem
-  //     definition={definition}
-  //     request={request}
-  //     renderDescription={() => <Description name={name} />}
-  //     renderBody={data => (
-  //       <DataTable
-  //         columns={columns}
-  //         dataDownloader
-  //         dataDownloaderFileStem="phenotypes"
-  //         rows={data.phenotypes}
-  //         showGlobalFilter
-  //       />
-  //     )}
-  //   />
-  // );
-  // return <>Phenotypes</>;
   return (
     <SectionItem
       definition={definition}
       request={request}
       renderDescription={() => <Description name={name} />}
       renderBody={data => {
-        console.log('table data:', data);
         // process the data
         const rows = [];
         data.disease.phenotypes.rows.forEach(p =>
@@ -291,13 +283,13 @@ function Body({ definition, label: name, id: efoId }) {
             rows.push(p1);
           })
         );
-        console.log('rows: ', rows);
+
         return (
           <DataTable
             columns={columns}
             rows={rows}
             dataDownloader
-            dataDownloaderFileStem="phenotypes"
+            dataDownloaderFileStem={`${efoId}-phenotypes`}
             showGlobalFilter
             rowsPerPageOptions={[10, 25, 50, 100]}
           />

--- a/src/sections/disease/Phenotypes/Body.js
+++ b/src/sections/disease/Phenotypes/Body.js
@@ -116,16 +116,19 @@ const columns = [
   {
     id: 'aspect',
     label: 'Aspect',
-    renderCell: ({ evidence }) => (
-      <Tooltip
-        title={`Sub-ontology: ${evidence.aspect} (${
-          aspectDescription[evidence.aspect]
-        })`}
-        showHelpIcon
-      >
-        {evidence.aspect}
-      </Tooltip>
-    ),
+    renderCell: ({ evidence }) =>
+      evidence.aspect ? (
+        <Tooltip
+          title={`Sub-ontology: ${evidence.aspect} (${
+            aspectDescription[evidence.aspect]
+          })`}
+          showHelpIcon
+        >
+          {evidence.aspect}
+        </Tooltip>
+      ) : (
+        naLabel
+      ),
     filterValue: row => row.evidence.aspect,
     exportValue: row => row.evidence.aspect,
     // width: '7%',

--- a/src/sections/disease/Phenotypes/Summary.js
+++ b/src/sections/disease/Phenotypes/Summary.js
@@ -19,10 +19,7 @@ function Summary({ definition }) {
     <SummaryItem
       definition={definition}
       request={request}
-      renderSummary={data => {
-        console.log('phenotypes: ', data);
-        return <>{data.phenotypes?.count || 0} phenotypes</>;
-      }}
+      renderSummary={data => <>{data.phenotypes?.count || 0} phenotypes</>}
     />
   );
 }

--- a/src/sections/disease/Phenotypes/Summary.js
+++ b/src/sections/disease/Phenotypes/Summary.js
@@ -21,7 +21,7 @@ function Summary({ definition }) {
       request={request}
       renderSummary={data => {
         console.log('phenotypes: ', data);
-        return <>{data.phenotypes.count} phenotypes</>;
+        return <>{data.phenotypes?.count || 0} phenotypes</>;
       }}
     />
   );

--- a/src/sections/disease/Phenotypes/index.js
+++ b/src/sections/disease/Phenotypes/index.js
@@ -2,7 +2,7 @@ export const definition = {
   id: 'phenotypes',
   name: 'Phenotypes',
   shortName: 'PH',
-  hasData: data => data.phenotypes.count > 0,
+  hasData: data => (data.phenotypes?.count || 0) > 0,
 };
 
 export { default as Summary } from './Summary';


### PR DESCRIPTION
This PR fixes the issues that were not addressed in the first implementation of the new phenotypes table. 
So far that includes:
 - handles `null` in the phenotypes endpoint https://github.com/opentargets/platform/issues/1376; will probably need a fix also in the known drugs table since for that example (HP_0000726) the drug table also crashes (drug is null)
 - fixes link in phenotype column
 - implements table search
 - fix table downloads
 - handle multiple publications in drawer

The following will be addressed separately:
 - implements disease synonyms correctly (also in evidence page?)
 - ideally fix column widths