### PR TITLE
Fix paging in tables with per-column filter dropdowns

### DIFF
--- a/src/components/ColumnFilteringDataTable.js
+++ b/src/components/ColumnFilteringDataTable.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import { Autocomplete } from '@material-ui/lab';
+import crossfilter from 'crossfilter2';
+import { TextField, Typography, Box } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
+import classNames from 'classnames';
+import _ from 'lodash';
+
+import { DataTable } from './Table';
+
+const ColumnFilteringDataTable = props => {
+  const classes = useStyles();
+  const [filteredRows, setFilteredRows] = React.useState(props.rows);
+  const xf = React.useRef(crossfilter()).current;
+  const dimensions = React.useRef({}).current;
+
+  React.useEffect(
+    () => {
+      xf.add(props.rows);
+      setFilteredRows(xf.allFiltered());
+      return () => {
+        xf.remove();
+      };
+    },
+    [props.rows, xf]
+  );
+
+  return (
+    <DataTable
+      {...props}
+      columns={props.columns.map(
+        ({ filterable, dropdownFilterValue, ...tableFields }) => {
+          const plainLabel = tableFields.label || _.startCase(tableFields.id);
+          if (!filterable) {
+            return {
+              ...tableFields,
+              // align the label above empty space as tall as the dropdowns
+              label: (
+                <>
+                  {plainLabel}
+                  <Box mb="72px" />
+                </>
+              ),
+              exportLabel: tableFields.exportLabel || plainLabel,
+            };
+          }
+          const valueAccessor =
+            dropdownFilterValue ||
+            (row =>
+              _.get(row, tableFields.propertyPath || tableFields.id, 'N/A'));
+          dimensions[tableFields.id] =
+            dimensions[tableFields.id] || xf.dimension(valueAccessor);
+          return {
+            ...tableFields,
+            label: (
+              <>
+                {plainLabel}
+                <FilterDropdown
+                  xf={xf}
+                  dim={dimensions[tableFields.id]}
+                  valueAccessor={valueAccessor}
+                  setFilteredRows={setFilteredRows}
+                />
+              </>
+            ),
+            exportLabel: tableFields.exportLabel || plainLabel,
+            // grow labels with dropdowns to full width even before sort arrows
+            classes: {
+              ...(tableFields.classes || {}),
+              sortLabel: classNames(
+                tableFields.classes?.sortLabel,
+                classes.fullWidthSortLabel
+              ),
+              innerLabel: classNames(
+                tableFields.classes?.innerLabel,
+                classes.assertiveInnerLabel
+              ),
+            },
+          };
+        }
+      )}
+      rows={filteredRows}
+    />
+  );
+};
+
+const useStyles = makeStyles({
+  fullWidthSortLabel: { width: '100%' },
+  assertiveInnerLabel: { flexGrow: 1 },
+});
+
+const FilterDropdown = ({ xf, dim, valueAccessor, setFilteredRows }) => {
+  const handler = (_event, selection) => {
+    if (selection) {
+      dim.filter(cellValue => {
+        if (_.isArray(cellValue)) {
+          return _.some(cellValue, arrayElement => arrayElement === selection);
+        } else {
+          return cellValue === selection;
+        }
+      });
+    } else {
+      dim.filterAll();
+    }
+
+    setFilteredRows(xf.allFiltered());
+  };
+  const cellValues = xf.allFiltered().flatMap(row => {
+    const cellValue = valueAccessor(row);
+    if (_.isArray(cellValue)) {
+      return cellValue;
+    } else {
+      return [cellValue];
+    }
+  });
+  const options = _.sortedUniq(cellValues.sort());
+  return (
+    <div
+      onClick={event => {
+        // stop clicks from bubbling up and changing the sort direction
+        event.stopPropagation();
+      }}
+    >
+      <Autocomplete
+        options={options}
+        onChange={handler}
+        renderInput={params => (
+          <TextField {...params} label="Select..." margin="normal" />
+        )}
+        renderOption={option => (
+          <Typography style={{ fontSize: '.85rem' }}>{option}</Typography>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ColumnFilteringDataTable;

--- a/src/components/FilteringOtTableRF.js
+++ b/src/components/FilteringOtTableRF.js
@@ -5,6 +5,9 @@ import OtTableRF from './OtTableRF';
 import { TextField, Typography } from '@material-ui/core';
 import _ from 'lodash';
 
+/**
+ * @deprecated in favour of ColumnFilteringDataTable, based on the new Table.
+ */
 const FilteringOtTableRF = props => {
   const [filteredRows, setFilteredRows] = React.useState(props.data);
   const xf = React.useRef(crossfilter()).current;

--- a/src/components/Table/DataTable.js
+++ b/src/components/Table/DataTable.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import Table from './Table';
 import { getPage } from './utils';
@@ -26,8 +26,14 @@ function DataTable({
   const [globalFilterVal, setGlobalFilterVal] = useState('');
   const [sortColumn, setSortColumn] = useState(sortBy);
   const [sortOrder, setSortOrder] = useState(order);
+  useEffect(
+    () => {
+      setPage(0);
+    },
+    [rows]
+  );
   const showPagination =
-    rows.length > [...rowsPerPageOptions, initialPageSize].sort()[0];
+    rows.length > Math.min(...rowsPerPageOptions, initialPageSize);
 
   const handleGlobalFilterChange = globalFilter => {
     setGlobalFilterVal(globalFilter);

--- a/src/sections/target/GeneOntology/OntologyTable.js
+++ b/src/sections/target/GeneOntology/OntologyTable.js
@@ -1,40 +1,22 @@
 import React, { Component, Fragment } from 'react';
-import { Autocomplete } from '@material-ui/lab';
-import crossfilter from 'crossfilter2';
-import { TextField } from '@material-ui/core';
 import _ from 'lodash';
 
-import DataDownloader from '../../../components/DataDownloader';
 import Link from '../../../components/Link';
-import OtTableRF from '../../../components/OtTableRF';
+import ColumnFilteringDataTable from '../../../components/ColumnFilteringDataTable';
 
 const capitalizeSnakeCase = term => {
   return _.capitalize(term.replace(/_/g, ' '));
 };
 
-const getColumns = (
-  categoryOptions,
-  categoryFilterHandler,
-  termOptions,
-  termFilterHandler,
-  uniprotId
-) => {
+const getColumns = uniprotId => {
   return [
     {
       id: 'category',
       label: 'Category',
       renderCell: row => capitalizeSnakeCase(row.category),
-      renderFilter: () => (
-        <Autocomplete
-          options={categoryOptions}
-          getOptionLabel={option => option.label}
-          getOptionSelected={option => option.value}
-          onChange={categoryFilterHandler}
-          renderInput={params => (
-            <TextField {...params} label="Select..." margin="normal" />
-          )}
-        />
-      ),
+      filterable: true,
+      dropdownFilterValue: row => capitalizeSnakeCase(row.category),
+      sortable: true,
     },
     {
       id: 'term',
@@ -49,20 +31,11 @@ const getColumns = (
           </Link>
         );
       },
-      renderFilter: () => (
-        <Autocomplete
-          options={termOptions}
-          getOptionLabel={option => option.label}
-          getOptionSelected={option => option.value}
-          onChange={termFilterHandler}
-          renderInput={params => (
-            <TextField {...params} label="Select..." margin="normal" />
-          )}
-        />
-      ),
+      filterable: true,
+      sortable: true,
     },
     {
-      id: 'references',
+      id: 'id',
       label: 'Annotation references',
       renderCell: row => {
         const quickGoLink = uniprotId
@@ -76,87 +49,25 @@ const getColumns = (
           </Link>
         );
       },
+      exportLabel: 'GO code',
     },
   ];
 };
 
-const downloadColumns = [
-  { id: 'id', label: 'GO code' },
-  { id: 'category', label: 'Category' },
-  { id: 'term', label: 'GO term' },
-];
-
-const getCategoryOptions = rows => {
-  return _.uniqBy(rows, 'category').map(row => ({
-    label: capitalizeSnakeCase(row.category),
-    value: row.category,
-  }));
-};
-
-const getTermOptions = rows => {
-  return _.uniqBy(rows, 'term').map(row => ({
-    label: row.term,
-    value: row.term,
-  }));
-};
-
 class OntologyTable extends Component {
-  state = {
-    filteredRows: this.props.rows,
-  };
-
-  categoryFilterHandler = (e, selection) => {
-    const { ontologyXf, categoryDim } = this;
-
-    if (selection) {
-      categoryDim.filter(d => d === selection.value);
-    } else {
-      categoryDim.filterAll();
-    }
-
-    this.setState({ filteredRows: ontologyXf.allFiltered() });
-  };
-
-  termFilterHandler = (e, selection) => {
-    const { ontologyXf, termDim } = this;
-
-    if (selection) {
-      termDim.filter(d => d === selection.value);
-    } else {
-      termDim.filterAll();
-    }
-
-    this.setState({ filteredRows: ontologyXf.allFiltered() });
-  };
-
-  componentDidMount() {
-    this.ontologyXf = crossfilter(this.props.rows);
-    this.categoryDim = this.ontologyXf.dimension(row => row.category);
-    this.termDim = this.ontologyXf.dimension(row => row.term);
-  }
-
   render() {
     const { symbol, rows, uniprotId } = this.props;
-    const { filteredRows } = this.state;
-    const categoryOptions = getCategoryOptions(rows);
-    const termOptions = getTermOptions(rows);
 
-    const columns = getColumns(
-      categoryOptions,
-      this.categoryFilterHandler,
-      termOptions,
-      this.termFilterHandler,
-      uniprotId
-    );
+    const columns = getColumns(uniprotId);
 
     return (
       <Fragment>
-        <DataDownloader
-          tableHeaders={downloadColumns}
-          rows={filteredRows}
-          fileStem={`${symbol}-gene-ontology`}
+        <ColumnFilteringDataTable
+          columns={columns}
+          rows={rows}
+          dataDownloader
+          dataDownloaderFileStem={`${symbol}-gene-ontology`}
         />
-        <OtTableRF columns={columns} data={filteredRows} filters />
       </Fragment>
     );
   }

--- a/src/sections/target/Pathways/OverviewTab.js
+++ b/src/sections/target/Pathways/OverviewTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import DataDownloader from '../../../components/DataDownloader';
-import FilteringOtTableRF from '../../../components/FilteringOtTableRF';
+import ColumnFilteringDataTable from '../../../components/ColumnFilteringDataTable';
 import Link from '../../../components/Link';
 
 const OverviewTab = ({ symbol, lowLevelPathways }) => (
@@ -11,12 +11,7 @@ const OverviewTab = ({ symbol, lowLevelPathways }) => (
       rows={lowLevelPathways}
       fileStem={`${symbol}-pathways`}
     />
-    <FilteringOtTableRF
-      loading={false}
-      error={null}
-      columns={columns}
-      data={lowLevelPathways}
-    />
+    <ColumnFilteringDataTable columns={columns} rows={lowLevelPathways} />
   </>
 );
 
@@ -25,6 +20,7 @@ const columns = [
     id: 'name',
     label: 'Pathway',
     filterable: true,
+    sortable: true,
   },
   {
     id: 'id',
@@ -35,6 +31,7 @@ const columns = [
       </Link>
     ),
     filterable: true,
+    sortable: true,
   },
   {
     id: 'parentNames',


### PR DESCRIPTION
The three tables that have per-column filter dropdowns show a bug when filtering down the number of rows after paging to the right, regardless of whether these tables use the *FilteringOtTableRF* abstraction. To reproduce:

* Navigate to a target profile page with more than 10 rows of **Gene Ontology**, **Pathways** or **Mouse Phenotypes** data, e.g. [AKT1](https://alpha.targetvalidation.org/target/ENSG00000142208)
* Click the **Last Page** arrow to the bottom-right of any of these tables, e.g. **Gene Ontology**
* Use one or more of the dropdowns to  get a subset of rows that wouldn't reach the last page, e.g. rows of which the **Category** is **Molecular function**
* You are now looking at an empty table, as it is still paged to row 171 and up while the table has only 16 rows. 
![Screenshot of the Gene Ontology table as described above](https://user-images.githubusercontent.com/4929431/108057042-5e7fe000-7052-11eb-9be8-87adb5ea6c15.png)


This pull request addresses the issue by correctly returning to page 1 if the set of rows changes, and simultaneously ports these three tables to the newly developed `<Table>` component.


I can see two potential issues with this change:
* The `<DataDownloader>` version used in the new table enforces that all column headers will be exported [in camelCase](https://github.com/opentargets/platform-app/blob/0d72c6bfa03675fd346cc56b6e59612e4d914785/src/components/Table/DataDownloader.js#L52). This will make column/field names in CSV/TSV/JSON exports of the Gene Ontology table incompatible with those exported before, as they were previously specifically set to [specific spaced and capitalised strings](https://github.com/opentargets/platform-app/blob/0d72c6bfa03675fd346cc56b6e59612e4d914785/src/sections/target/GeneOntology/OntologyTable.js#L84).
* If any sections replace the array of rows passed to a (client-side) `<DataTable>` on rerender for another reason, this also resets the page to 1