### PR TITLE
Google Tag Manager loading rework

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,6 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[context.production.environemt]
+  REACT_APP_ADD_GTM = "true"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.8.6",
     "react-ga": "^3.0.0",
-    "react-gtm-module": "^2.0.11",
     "react-helmet": "^6.0.0",
     "react-measure": "^2.1.2",
     "react-router-dom": "5.1.2",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <% if (process.env.REACT_APP_ADD_GTM) { %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WPXWRDV');</script>
+    <!-- End Google Tag Manager -->
+    <% } %>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
@@ -31,6 +40,12 @@
     <title>Open Targets Platform</title>
   </head>
   <body>
+    <% if (process.env.REACT_APP_ADD_GTM) { %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WPXWRDV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <% } %>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
     <!--

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Refiner from 'refiner-js';
-import TagManager from 'react-gtm-module';
 
 import App from './App';
 
@@ -13,10 +12,9 @@ import App from './App';
 import 'dc/dc.min.css';
 import './index.scss';
 
-// Add Google Tag Manager and refiner.io popup in production
+// Add refiner.io popup in production
 if (process.env.NODE_ENV === 'production') {
   Refiner('setProject', 'ade7da40-a960-11ea-9bbb-37035544d167');
-  TagManager.initialize({ gtmId: 'GTM-WPXWRDV' });
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -13312,11 +13312,6 @@ react-ga@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.0.0.tgz#4d665389cf0c489c36c5fdf97722a7e53efdfc5b"
   integrity sha512-IKqqCtSMe0IfSRNvbHAiwXwIXbuza4VvHvB/2N3hEiMFGSjv8fNI6obPH6bkDdIjDpwzbUqKs8895OxBckWJ2g==
 
-react-gtm-module@^2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
-  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
-
 react-helmet@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"


### PR DESCRIPTION
This PR:

- Removes the react-gtm-module package used to load the google tag manager scripts
- It uses create-react-app already included functionality to dynamically include pieces of HTML depending on environment variables
- Adds an environment variable in netlify.toml in production context to indicate the addition of the GTM scripts