### PR TITLE
Fix mouse phenotypes publications

### DIFF
--- a/src/sections/target/MousePhenotypes/PhenotypesTable.js
+++ b/src/sections/target/MousePhenotypes/PhenotypesTable.js
@@ -86,6 +86,9 @@ const getColumns = (
       id: 'pmIds',
       label: 'Sources',
       renderCell: row => {
+        if (row.pmIds.length === 0) {
+          return 'N/A';
+        }
         const query = row.pmIds.map(pmId => `EXT_ID:${pmId}`).join(' OR ');
         return (
           <Link external to={`https://europepmc.org/search?query=${query}`}>
@@ -257,7 +260,10 @@ const transformToRows = mousePhenotypes => {
           ),
           subjectBackground: phenotypeGenotype.subjectBackground,
           //FIXME splitting has to be removed after updating the graphql backend
-          pmIds: phenotypeGenotype.pubmedId.split(','),
+          pmIds:
+            phenotypeGenotype.pubmedId.length === 0
+              ? []
+              : phenotypeGenotype.pubmedId.split('|'),
         });
       }
     }


### PR DESCRIPTION
This fixes the broken links in publications after backend change.
It's a quick and dirty fix, since backend schema is being redone.