### PR TITLE
Publication drawer in sysbio component

### DIFF
--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -175,7 +175,7 @@ const columns = [
     },
   },
   {
-    label: 'Literatures',
+    label: 'Literature',
     renderCell: ({ literature }) => {
       const literatureList =
         literature?.reduce((acc, id) => {

--- a/src/sections/evidence/SysBio/Body.js
+++ b/src/sections/evidence/SysBio/Body.js
@@ -6,6 +6,7 @@ import Description from './Description';
 import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import { epmcUrl } from '../../../utils/urls';
 import Link from '../../../components/Link';
+import PublicationsDrawer from '../../../components/PublicationsDrawer';
 import SectionItem from '../../../components/Section/SectionItem';
 import Summary from './Summary';
 import Tooltip from '../../../components/Tooltip';
@@ -66,14 +67,20 @@ const columns = [
   },
   {
     id: 'literature',
-    renderCell: ({ literature }) =>
-      literature?.[0] ? (
-        <Link external to={epmcUrl(literature[0])}>
-          {literature[0]}
-        </Link>
-      ) : (
-        naLabel
-      ),
+    renderCell: ({ literature }) => {
+      const literatureList =
+        literature?.reduce((acc, id) => {
+          if (id !== 'NA') {
+            acc.push({
+              name: id,
+              url: epmcUrl(id),
+              group: 'literature',
+            });
+          }
+          return acc;
+        }, []) || [];
+      return <PublicationsDrawer entries={literatureList} />;
+    },
   },
 ];
 


### PR DESCRIPTION
- The sysbio widget (gene signatures) has not the drawer functionality incorporated
- The clinvar (somatic) widget has as column named Literatures instead of Literature