### PR TITLE
Lf interactions fixes

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -12,16 +12,14 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
 
 const client = new ApolloClient({
   link: new HttpLink({
-    uri:
-      'https://api-beta-dot-open-targets-eu-dev.ew.r.appspot.com/api/v4/graphql',
+    uri: 'https://api-beta-dot-open-targets-eu-dev.appspot.com/api/v4/graphql',
   }),
   cache: new InMemoryCache({ fragmentMatcher }),
 });
 
 const betaClient = new ApolloClient({
   link: new HttpLink({
-    uri:
-      'https://api-beta-dot-open-targets-eu-dev.ew.r.appspot.com/api/v4/graphql',
+    uri: 'https://api-beta-dot-open-targets-eu-dev.appspot.com/api/v4/graphql',
   }),
   cache: new InMemoryCache({ fragmentMatcher }),
 });

--- a/src/sections/target/MolecularInteractions/IntactTab.js
+++ b/src/sections/target/MolecularInteractions/IntactTab.js
@@ -91,10 +91,10 @@ const columns = {
       width: '40%',
     },
     {
-      id: 'scoring',
+      id: 'score',
       label: 'Score',
-      renderCell: row => row.scoring.toFixed(2),
-      exportValue: row => row.scoring.toFixed(2),
+      renderCell: row => row.score.toFixed(2),
+      exportValue: row => row.score.toFixed(2),
       width: '14%',
     },
     {

--- a/src/sections/target/MolecularInteractions/InteractionsQuery.gql
+++ b/src/sections/target/MolecularInteractions/InteractionsQuery.gql
@@ -33,7 +33,7 @@ query InteractionsSectionQuery(
         speciesB {
           mnemonic
         }
-        scoring
+        score
         count
         sourceDatabase
         evidences {

--- a/src/sections/target/MolecularInteractions/InteractionsStringQuery.gql
+++ b/src/sections/target/MolecularInteractions/InteractionsStringQuery.gql
@@ -17,7 +17,7 @@ query InteractionsSectionQuery(
           approvedSymbol
           id
         }
-        scoring
+        score
         evidences {
           evidenceScore
           interactionDetectionMethodShortName

--- a/src/sections/target/MolecularInteractions/StringTab.js
+++ b/src/sections/target/MolecularInteractions/StringTab.js
@@ -139,9 +139,9 @@ function getColumns(classes) {
         sortLabel: classes.sortLabel,
         innerLabel: classes.innerLabel,
       },
-      renderCell: row => row.scoring.toFixed(3),
-      exportValue: row => row.scoring.toFixed(3),
-      filterValue: row => row.scoring.toFixed(3),
+      renderCell: row => row.score.toFixed(3),
+      exportValue: row => row.score.toFixed(3),
+      filterValue: row => row.score.toFixed(3),
     },
     {
       id: 'neighbourhood',

--- a/src/sections/target/MolecularInteractions/StringTab.js
+++ b/src/sections/target/MolecularInteractions/StringTab.js
@@ -277,14 +277,11 @@ function getColumns(classes) {
         innerLabel: classes.innerLabel,
       },
       renderCell: row =>
-        getHeatmapCell(
-          getScoreForColumn(row.evidences, 'by homology'),
-          classes
-        ),
+        getHeatmapCell(getScoreForColumn(row.evidences, 'homology'), classes),
       exportValue: row =>
-        getScoreForColumn(row.evidences, 'by homology')?.toFixed(3),
+        getScoreForColumn(row.evidences, 'homology')?.toFixed(3),
       filterValue: row =>
-        getScoreForColumn(row.evidences, 'by homology')?.toFixed(3),
+        getScoreForColumn(row.evidences, 'homology')?.toFixed(3),
     },
   ];
 }


### PR DESCRIPTION
Short PR updates the molecular interactions widget to handle new changes introduced in the API.
 - Update dev API url 
 - Update filtering of homology data in String heatmap
 - Change "scoring" field to "score" in queries and tables