### PR TITLE
Change (default) order of drug profile page widgets

### DIFF
--- a/src/pages/DrugPage/sections.js
+++ b/src/pages/DrugPage/sections.js
@@ -7,10 +7,10 @@ import * as MechanismsOfAction from '../../sections/drug/MechanismsOfAction';
 import * as Pharmacovigilance from '../../sections/drug/AdverseEvents';
 
 export default [
-  DrugWarnings,
-  Indications,
   MechanismsOfAction,
+  Indications,
   ClinicalPrecedence,
+  DrugWarnings,
   Pharmacovigilance,
   Bibliography,
 ];


### PR DESCRIPTION
I just wanted to ask someone to change the default order of the drug profile page widgets... then I realised it was probably easier to do it than create the ticket 