### PR TITLE
Lf evidencefix clinvar somatic

### DIFF
--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -35,6 +35,7 @@ const EVA_SOMATIC_QUERY = gql`
             name
           }
           diseaseFromSource
+          variantId
           variantRsId
           studyId
           clinicalSignificances
@@ -86,19 +87,38 @@ const columns = [
   },
   {
     id: 'variantRsId',
-    label: 'Variant',
-    renderCell: ({ variantRsId }) => {
-      return variantRsId ? (
-        <Link
-          external
-          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
-        >
-          {variantRsId}
-        </Link>
+    label: 'Variant ID (RSID)',
+    renderCell: ({ variantId, variantRsId }) => {
+      return variantId ? (
+        <>
+          <Link
+            external
+            to={`https://genetics.opentargets.org/variant/${variantId}`}
+          >
+            {variantId.substring(0, 20)}
+            {variantId.length > 20 ? '\u2026' : ''}
+          </Link>
+          {variantRsId ? (
+            <>
+              {' '}
+              (
+              <Link
+                external
+                to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+              >
+                {variantRsId}
+              </Link>
+              )
+            </>
+          ) : (
+            ''
+          )}
+        </>
       ) : (
         naLabel
       );
     },
+    filterValue: ({ variantId, variantRsId }) => `${variantId} ${variantRsId}`,
   },
   {
     id: 'studyId',

--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -83,7 +83,7 @@ const columns = [
                 {diseaseFromSource}
               </Typography>
 
-              {cohortPhenotypes?.length > 0 ? (
+              {cohortPhenotypes?.length > 1 ? (
                 <>
                   <Typography
                     variant="subtitle2"

--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -43,6 +43,7 @@ const EVA_SOMATIC_QUERY = gql`
           alleleOrigins
           confidence
           literature
+          cohortPhenotypes
         }
       }
     }
@@ -65,7 +66,7 @@ const columns = [
   {
     id: 'disease.name',
     label: 'Disease/phenotype',
-    renderCell: ({ disease, diseaseFromSource }) => {
+    renderCell: ({ disease, diseaseFromSource, cohortPhenotypes }) => {
       return (
         <Tooltip
           title={
@@ -73,9 +74,33 @@ const columns = [
               <Typography variant="subtitle2" display="block" align="center">
                 Reported disease or phenotype:
               </Typography>
-              <Typography variant="caption" display="block" align="center">
+              <Typography
+                variant="caption"
+                display="block"
+                align="center"
+                gutterBottom
+              >
                 {diseaseFromSource}
               </Typography>
+
+              {cohortPhenotypes?.length > 0 ? (
+                <>
+                  <Typography
+                    variant="subtitle2"
+                    display="block"
+                    align="center"
+                  >
+                    All reported phenotypes:
+                  </Typography>
+                  <Typography variant="caption" display="block">
+                    {cohortPhenotypes.map(cp => (
+                      <div key={cp}>{cp}</div>
+                    ))}
+                  </Typography>
+                </>
+              ) : (
+                ''
+              )}
             </>
           }
           showHelpIcon

--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -116,13 +116,8 @@ const columns = [
     renderCell: ({ variantId, variantRsId }) => {
       return variantId ? (
         <>
-          <Link
-            external
-            to={`https://genetics.opentargets.org/variant/${variantId}`}
-          >
-            {variantId.substring(0, 20)}
-            {variantId.length > 20 ? '\u2026' : ''}
-          </Link>
+          {variantId.substring(0, 20)}
+          {variantId.length > 20 ? '\u2026' : ''}
           {variantRsId ? (
             <>
               {' '}

--- a/src/sections/evidence/EVASomatic/Body.js
+++ b/src/sections/evidence/EVASomatic/Body.js
@@ -39,6 +39,7 @@ const EVA_SOMATIC_QUERY = gql`
           studyId
           clinicalSignificances
           allelicRequirements
+          alleleOrigins
           confidence
           literature
         }
@@ -140,27 +141,34 @@ const columns = [
   },
   {
     id: 'allelicRequirements',
-    label: 'Allelic requirement',
-    renderCell: ({ allelicRequirements }) => {
-      return !allelicRequirements ? (
+    label: 'Allele origin',
+    renderCell: ({ alleleOrigins, allelicRequirements }) => {
+      return !alleleOrigins || alleleOrigins.length === 0 ? (
         naLabel
-      ) : allelicRequirements.length === 1 ? (
-        allelicRequirements[0]
-      ) : (
-        <ul
-          style={{
-            margin: 0,
-            padding: 0,
-            listStyle: 'none',
-          }}
+      ) : allelicRequirements ? (
+        <Tooltip
+          title={
+            <>
+              <Typography variant="subtitle2" display="block" align="center">
+                Allelic requirements:
+              </Typography>
+              {allelicRequirements.map(r => (
+                <Typography variant="caption" key={r}>
+                  {r}
+                </Typography>
+              ))}
+            </>
+          }
+          showHelpIcon
         >
-          {allelicRequirements.map(allelicRequirement => {
-            return <li key={allelicRequirement}>{allelicRequirement}</li>;
-          })}
-        </ul>
+          {alleleOrigins.map(a => sentenceCase(a)).join('; ')}
+        </Tooltip>
+      ) : (
+        alleleOrigins.map(a => sentenceCase(a)).join('; ')
       );
     },
-    filterValue: ({ allelicRequirements }) => allelicRequirements.join(),
+    filterValue: ({ alleleOrigins }) =>
+      alleleOrigins ? alleleOrigins.join() : '',
   },
   {
     label: 'Review status',


### PR DESCRIPTION
Updates the ClinVar Somatic widget as per issue opentargets/platform#1466 :

update disease/phenotype column tooltip
rename allele requirement column to allele origin and add tooltip
rename variant column and display both id and rsid

NOTE: these changes are essentially the same as PR #354 