### PR TITLE
Fix documentation links

### DIFF
--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -36,7 +36,7 @@ function Legend() {
           1
         </div>
       </div>
-      <Link href="https://docs.targetvalidation.org/getting-started/scoring">
+      <Link href="https://platform-docs.opentargets.org/associations#association-scores">
         <FontAwesomeIcon icon={faQuestionCircle} size="xs" /> Score
       </Link>
     </div>

--- a/src/pages/EmptyPage/EmptyPage.js
+++ b/src/pages/EmptyPage/EmptyPage.js
@@ -44,7 +44,7 @@ const EmptyPage = ({ classes, children }) => {
       <Typography gutterBottom>You might also want to ...</Typography>
       <Grid item container justify="center">
         <Grid item container direction="column" md={2} alignItems="center">
-          <a href="https://docs.targetvalidation.org/getting-started/getting-started">
+          <a href="https://platform-docs.opentargets.org/">
             <Icon
               className="fa fa-question-circle"
               color="primary"
@@ -56,15 +56,15 @@ const EmptyPage = ({ classes, children }) => {
           </Typography>
         </Grid>
         <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:support@targetvalidation.org">
+          <a href="mailto:helpdesk@opentargets.org">
             <Icon className="fa fa-envelope" color="primary" fontSize="large" />
           </a>
           <Typography align="center" className={classes.actionText}>
-            Contact our support team
+            Contact the Platform helpdesk
           </Typography>
         </Grid>
         <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:support@targetvalidation.org">
+          <a href="mailto:helpdesk@opentargets.org">
             <Icon
               className="fa fa-search-plus"
               color="primary"

--- a/src/sections/drug/AdverseEvents/Description.js
+++ b/src/sections/drug/AdverseEvents/Description.js
@@ -9,7 +9,7 @@ function Description({ name }) {
       estimated from reports submitted to the FDA Adverse Event Reporting
       database by healthcare professionals. Source:{' '}
       <Link
-        to="https://docs.targetvalidation.org/getting-started/getting-started/drug-summary/pharmacovigilance"
+        to="https://platform-docs.opentargets.org/drug/pharmacovigilence"
         external
       >
         Open Targets

--- a/src/sections/evidence/OTGenetics/Body.js
+++ b/src/sections/evidence/OTGenetics/Body.js
@@ -173,7 +173,7 @@ const columns = [
         Causal inference score - see{' '}
         <Link
           external
-          to="https://docs.targetvalidation.org/data-sources/genetic-associations#open-targets-genetics-portal"
+          to="https://platform-docs.opentargets.org/evidence#open-targets-genetics-portal"
         >
           our documentation
         </Link>{' '}

--- a/src/sections/target/MolecularInteractions/Description.js
+++ b/src/sections/target/MolecularInteractions/Description.js
@@ -5,23 +5,38 @@ const Description = ({ symbol }) => (
   <React.Fragment>
     Physical and functional molecular interactions with{' '}
     <strong>{symbol}</strong>. Source:{' '}
-    <Link to="https://docs.targetvalidation.org/data-sources/" external>
+    <Link
+      to="https://platform-docs.opentargets.org/target/molecular-interactions"
+      external
+    >
       Open Targets
     </Link>
     ,{' '}
-    <Link to="https://docs.targetvalidation.org/data-sources/" external>
+    <Link
+      to="https://platform-docs.opentargets.org/target/molecular-interactions#intact"
+      external
+    >
       IntAct
     </Link>
     ,{' '}
-    <Link to="https://docs.targetvalidation.org/data-sources/" external>
+    <Link
+      to="https://platform-docs.opentargets.org/target/molecular-interactions#signor"
+      external
+    >
       Signor
     </Link>
     ,{' '}
-    <Link to="https://docs.targetvalidation.org/data-sources/" external>
+    <Link
+      to="https://platform-docs.opentargets.org/target/molecular-interactions#reactome"
+      external
+    >
       Reactome
     </Link>
     ,{' '}
-    <Link to="https://docs.targetvalidation.org/data-sources/" external>
+    <Link
+      to="https://platform-docs.opentargets.org/target/molecular-interactions#string"
+      external
+    >
       String
     </Link>
   </React.Fragment>

--- a/src/sections/target/RelatedTargets/Description.js
+++ b/src/sections/target/RelatedTargets/Description.js
@@ -7,10 +7,7 @@ function Description({ symbol }) {
     <>
       Targets that are similar to <strong>{symbol}</strong> based on their
       disease association profiles. Source:{' '}
-      <Link
-        external
-        to="https://docs.targetvalidation.org/faq/how-do-you-compute-target-and-disease-similarities"
-      >
+      <Link external to="https://platform-docs.opentargets.org/">
         Open Targets
       </Link>
       .

--- a/src/sections/target/Safety/Description.js
+++ b/src/sections/target/Safety/Description.js
@@ -7,10 +7,7 @@ function Description({ symbol }) {
     <>
       Known target safety effects and target safety risk information for{' '}
       <strong>{symbol}</strong>. Source:{' '}
-      <Link
-        external
-        to="https://docs.targetvalidation.org/getting-started/target-safety"
-      >
+      <Link external to="https://platform-docs.opentargets.org/target/safety">
         Open Targets
       </Link>
       .

--- a/src/sections/target/Tractability/Description.js
+++ b/src/sections/target/Tractability/Description.js
@@ -8,7 +8,7 @@ function Description({ symbol }) {
       Target druggability assessment for <strong>{symbol}</strong>. Source:{' '}
       <Link
         external
-        to="https://docs.targetvalidation.org/getting-started/target-tractability"
+        to="https://platform-docs.opentargets.org/target/tractability"
       >
         Open Targets
       </Link>


### PR DESCRIPTION
This PR addresses https://github.com/opentargets/platform/issues/1499 and fixes various documentation links with the correct URL - `https://platform-docs.opentargets.org`.

Once reviewed and approved, please merge into `main`.