### PR TITLE
Additional UI changes

### DIFF
--- a/src/components/ExternalLink/CrisprDepmapLink.js
+++ b/src/components/ExternalLink/CrisprDepmapLink.js
@@ -44,7 +44,7 @@ function CrisprDepmapLink({ symbol }) {
 
   return (
     <span>
-      CRISPR depmap
+      Project Score
       <Tooltip
         classes={{ tooltip: classes.tooltip }}
         title="CRISPR-Cas9 cancer cell line dependency data from Project Score"

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ import {
   faGithubSquare,
   faYoutubeSquare,
 } from '@fortawesome/free-brands-svg-icons';
+import { config } from './config/Config';
 
 export const externalLinks = {
   about: [
@@ -84,7 +85,7 @@ export const mainMenuItems = [
   // API
   {
     name: 'API',
-    url: 'https://platform-docs.opentargets.org/data-access/graphql-api',
+    url: config.urlApi.split('/api/v4/graphql')[0],
     external: true,
   },
   // Community

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -182,7 +182,7 @@ const HomePage = () => {
           </Typography>
 
           <Typography paragraph>
-            By integrating publicly available datasets along with data generated
+            By integrating publicly available datasets including data generated
             by the Open Targets consortium, the Platform builds and scores
             target-disease associations to assist in drug target identification
             and prioritisation. It also integrates relevant annotation

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -30,6 +30,8 @@ import {
   faCommentDots,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { config } from '../../config/Config';
+
 const useStyles = makeStyles(theme => ({
   links: {
     marginTop: '12px',
@@ -225,7 +227,7 @@ const HomePage = () => {
             <Grid item xs={12} sm={'auto'}>
               <HelpBoxPanel
                 fai={faLaptopCode}
-                url="https://platform-docs.opentargets.org/data-access/graphql-api"
+                url={config.urlApi.split('/api/v4/graphql')[0]}
                 label="Access data with our GraphQL API"
                 external
               />

--- a/src/sections/evidence/OTGenetics/Body.js
+++ b/src/sections/evidence/OTGenetics/Body.js
@@ -70,7 +70,7 @@ const columns = [
             (
             <Link
               external
-              to={identifiersOrgLink('DBSNP', variantRsId, 'ncbi')}
+              to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
             >
               {variantRsId}
             </Link>

--- a/src/sections/evidence/PheWASCatalog/Body.js
+++ b/src/sections/evidence/PheWASCatalog/Body.js
@@ -81,7 +81,10 @@ const columns = [
     renderCell: ({ variantRsId, variantId }) => {
       return (
         <>
-          <Link external to={identifiersOrgLink('DBSNP', variantRsId, 'ncbi')}>
+          <Link
+            external
+            to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+          >
             {variantRsId}
           </Link>{' '}
           {variantId ? (

--- a/src/sections/evidence/UniProtVariants/Body.js
+++ b/src/sections/evidence/UniProtVariants/Body.js
@@ -83,7 +83,10 @@ const columns = [
     label: 'Variant',
     renderCell: ({ variantRsId }) => {
       return (
-        <Link external to={identifiersOrgLink('ensembl', variantRsId)}>
+        <Link
+          external
+          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+        >
           {variantRsId}
         </Link>
       );

--- a/src/sections/target/Safety/SafetyTables.js
+++ b/src/sections/target/Safety/SafetyTables.js
@@ -59,8 +59,8 @@ const SafetyTables = ({ symbol, data }) => {
             Non-clinical experimental toxicity
           </Typography>
           <Typography variant="body2">
-            Details on the routine testing and screening of {symbol} in
-            non-clinical experimental toxicity panels.
+            Details of assays that can be used to test for {symbol} toxicity in
+            vitro.
           </Typography>
           <SeparatedByDividers>
             {hasTox21 && (

--- a/src/sections/target/Tractability/Body.js
+++ b/src/sections/target/Tractability/Body.js
@@ -181,7 +181,7 @@ function Body({ definition, label: symbol }) {
             {smallMoleculeBuckets.length > 0 ? (
               <SmallMoleculeTable buckets={smallMoleculeBuckets} />
             ) : (
-              <Typography>
+              <Typography variant="body2">
                 No small molecule tractability data for {symbol} available
               </Typography>
             )}
@@ -189,7 +189,7 @@ function Body({ definition, label: symbol }) {
             {antibodyBuckets.length > 0 ? (
               <AntibodyTable buckets={antibodyBuckets} />
             ) : (
-              <Typography>
+              <Typography variant="body2">
                 No antibody tractability data for {symbol} available
               </Typography>
             )}


### PR DESCRIPTION
This PR has the following changes:

- Fixed links to Ensembl in Open Targets Genetics, PheWAS Catalog, and UniProt variants sections on evidence page (see https://main--platform-app.netlify.app/evidence/ENSG00000167207/EFO_0003767 for an example)
- Updates navigation menu and homepage links to GraphQL API using `config.urlApi` value with split function used to remove path