### PR TITLE
Fix Bibliography when missing entries

### DIFF
--- a/src/sections/common/SimilarEntities/Body.js
+++ b/src/sections/common/SimilarEntities/Body.js
@@ -156,9 +156,9 @@ function LiteratureList({ id, name, entity, BODY_QUERY }) {
           entity
         ].literatureOcurrences;
         setCursor(newCursor);
+        setPageSize(newPageSize);
         setPage(0);
         setRows([...rows, ...newRows?.map(({ pmid }) => pmid)]);
-        setPageSize(newPageSize);
         setLoading(false);
       });
     } else {
@@ -185,7 +185,7 @@ function LiteratureList({ id, name, entity, BODY_QUERY }) {
         </Box>
         {!initialLoading && (
           <Typography variant="body2" className={classes.resultCount}>
-            Showing {count > 5 ? 5 : count} of {count} results
+            Showing {count > pageSize ? pageSize : count} of {count} results
           </Typography>
         )}
       </Box>

--- a/src/sections/common/SimilarEntities/PublicationsList.js
+++ b/src/sections/common/SimilarEntities/PublicationsList.js
@@ -61,7 +61,11 @@ const PublicationsList = ({
         .then(data => {
           const all = [...publications, ...data.resultList.result];
           const mapedResults = new Map(all.map(key => [key.pmid, key]));
-          const ordered = entriesIds.map(key => mapedResults.get(key));
+          const ordered = entriesIds.reduce((acc, key) => {
+            const pub = mapedResults.get(key);
+            if (pub) acc.push(pub);
+            return acc;
+          }, []);
           setPublications(ordered);
           setLoading(false);
         });
@@ -103,7 +107,7 @@ const PublicationsList = ({
       columns={columns}
       rows={rows}
       rowCount={count}
-      rowsPerPageOptions={[5, 10, 25, 50]}
+      rowsPerPageOptions={[5, 10, 25]}
       page={page}
       pageSize={pageSize}
       onPageChange={handlePageChange}

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -39,13 +39,13 @@ export function europePmcSearchPOSTQuery(ids) {
   return { baseUrl, formBody };
 }
 
-export function europePmcBiblioSearchPOSTQuery(ids) {
+export function europePmcBiblioSearchPOSTQuery(ids, size = 25) {
   const baseUrl = 'https://www.ebi.ac.uk/europepmc/webservices/rest/searchPOST';
   const query = ids.join(' OR ext_id:');
   const bodyOptions = {
     resultType: 'core',
     format: 'json',
-    pageSize: '25',
+    pageSize: size,
     query: `SRC:MED AND (ext_id:${query})`,
   };
   const formBody = encodeParams(bodyOptions);


### PR DESCRIPTION
Example: https://platform.opentargets.org/drug/CHEMBL590799

This was happening because EuropePMC does not return results for the values:
- 32596694
- 32793911

https://europepmc.org/search?query=32596694%2032793911%20%28SRC%3A%22AGR%22%20OR%20SRC%3A%22CBA%22%20OR%20SRC%3A%22CTX%22%20OR%20SRC%3A%22PAT%22%20OR%20SRC%3A%22PPR%22%20OR%20SRC%3A%22MED%22%29

This is a partial fix that prevents the Literature section to crash, we need to handle better the data state between the components.
