### PR TITLE
Remove graphql-tag package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "file-saver": "^1.3.8",
     "graphql": "^15.0.0",
     "graphql-anywhere": "^4.2.7",
-    "graphql-tag": "^2.10.3",
     "graphql.macro": "^1.4.2",
     "litemol": "^2.4.2",
     "local-storage": "^2.0.0",

--- a/src/pages/DiseasePage/ClassicAssociationsTable.js
+++ b/src/pages/DiseasePage/ClassicAssociationsTable.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import Link from '../../components/Link';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7244,7 +7244,7 @@ graphql-anywhere@^4.2.7:
     ts-invariant "^0.3.2"
     tslib "^1.10.0"
 
-graphql-tag@^2.10.1, graphql-tag@^2.10.3:
+graphql-tag@^2.10.1:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==


### PR DESCRIPTION
Remove graphql-tag package dependency since `@apollo/client` already exports `gql` to parse graphql queries.