### PR TITLE
Lf canonical

### DIFF
--- a/src/components/BasePage.js
+++ b/src/components/BasePage.js
@@ -8,11 +8,12 @@ import Footer from './Footer';
 import {
   appTitle,
   appDescription,
+  appCanonicalUrl,
   externalLinks,
   mainMenuItems,
 } from '../constants';
 
-const BasePage = ({ title, children, description }) => {
+const BasePage = ({ title, children, description, location }) => {
   const composedTitle = `${title ? title + ' | ' : ''} ${appTitle}`;
 
   return (
@@ -28,6 +29,10 @@ const BasePage = ({ title, children, description }) => {
     >
       <Helmet title={composedTitle}>
         <meta name="description" content={description || appDescription} />
+        <link
+          rel="canonical"
+          href={appCanonicalUrl + (location?.pathname || '')}
+        />
       </Helmet>
       {children}
     </Page>

--- a/src/constants.js
+++ b/src/constants.js
@@ -217,6 +217,7 @@ export const particlesConfig = {
 export const appTitle = 'Open Targets Platform';
 export const appDescription =
   'The Open Targets Platform is a data integration tool that supports systematic drug target identification and prioritisation';
+export const appCanonicalUrl = 'https://platform.opentargets.org';
 
 // Chunk sizes for server side pagination/download.
 export const tableChunkSize = 100;

--- a/src/pages/DiseasePage/DiseasePage.js
+++ b/src/pages/DiseasePage/DiseasePage.js
@@ -35,6 +35,7 @@ function DiseasePage({ location, match }) {
           ? `Ranked list of targets associated with ${name}`
           : `Annotation information for ${name}`
       }
+      location={location}
     >
       <Header loading={loading} efoId={efoId} name={name} />
       <ScrollToTop />

--- a/src/pages/DownloadsPage/DownloadsPage.js
+++ b/src/pages/DownloadsPage/DownloadsPage.js
@@ -89,7 +89,7 @@ function getVersion(data) {
   return `${year}.${month < 10 ? '0' : ''}${month}`;
 }
 
-function DownloadsPage() {
+function DownloadsPage({ location }) {
   const { data, loading, error } = useQuery(DATA_VERSION_QUERY);
   const columns = loading || error ? [] : getColumns(data.meta.dataVersion);
 
@@ -97,6 +97,7 @@ function DownloadsPage() {
     <BasePage
       title="Data downloads"
       description="List of open source and open access datasets that are available for download from the Open Targets Platform in various formats"
+      location={location}
     >
       <Typography variant="h4" component="h1" paragraph>
         Data downloads

--- a/src/pages/DrugPage/DrugPage.js
+++ b/src/pages/DrugPage/DrugPage.js
@@ -11,7 +11,7 @@ import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
 
 const DRUG_PAGE_QUERY = loader('./DrugPage.gql');
 
-function DrugPage({ match }) {
+function DrugPage({ location, match }) {
   const { chemblId } = match.params;
   const { loading, data } = useQuery(DRUG_PAGE_QUERY, {
     variables: { chemblId },
@@ -27,6 +27,7 @@ function DrugPage({ match }) {
     <BasePage
       title={`${name || chemblId} profile page`}
       description={`Annotation information for ${name || chemblId}`}
+      location={location}
     >
       <Header
         loading={loading}

--- a/src/pages/EvidencePage/EvidencePage.js
+++ b/src/pages/EvidencePage/EvidencePage.js
@@ -11,7 +11,7 @@ import Profile from './Profile';
 
 const EVIDENCE_PAGE_QUERY = loader('./EvidencePageQuery.gql');
 
-function EvidencePage({ match }) {
+function EvidencePage({ location, match }) {
   const { ensgId, efoId } = match.params;
   const { loading, data } = useQuery(EVIDENCE_PAGE_QUERY, {
     variables: { ensgId, efoId },
@@ -28,6 +28,7 @@ function EvidencePage({ match }) {
     <BasePage
       title={`Evidence for ${symbol} and ${name}`}
       description={`${symbol} is associated with ${name} through Open Targets Platform evidence that is aggregated from genetic evidence, somatic mutations, known drugs, differential expression experiments, pathways & systems biology, text mining, and animal model data sources`}
+      location={location}
     >
       <Header
         loading={loading}

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -13,6 +13,7 @@ import { Helmet } from 'react-helmet';
 import {
   appTitle,
   appDescription,
+  appCanonicalUrl,
   externalLinks,
   mainMenuItems,
 } from '../../constants';
@@ -116,6 +117,7 @@ const HomePage = () => {
     <>
       <Helmet title={appTitle}>
         <meta name="description" content={appDescription} />
+        <link rel="canonical" href={appCanonicalUrl} />
       </Helmet>
       <Grid
         container

--- a/src/pages/TargetPage/TargetPage.js
+++ b/src/pages/TargetPage/TargetPage.js
@@ -38,6 +38,7 @@ function TargetPage({ location, match }) {
           ? `Ranked list of diseases and phenotypes associated with ${symbol}`
           : `Annotation information for ${symbol}`
       }
+      location={location}
     >
       <ScrollToTop />
       <Header

--- a/src/pages/VariantsPage/VariantsPage.js
+++ b/src/pages/VariantsPage/VariantsPage.js
@@ -319,11 +319,12 @@ const columns = [
   },
 ];
 
-const VariantsPage = () => {
+const VariantsPage = ({ location }) => {
   return (
     <BasePage
       title="Variant definitions"
       description="Variant definitions, including Sequence Ontology (SO) consequence terms, descriptions, and accession IDs"
+      location={location}
     >
       <Typography variant="h4" component="h1" paragraph>
         Variant definitions


### PR DESCRIPTION
Add canonical link tags to pages as per issue https://github.com/opentargets/platform/issues/1524
Essentially `location.pathname` is passed to the BasePage component.