### PR TITLE
Update HeCaTos url and remove tooltip

### DIFF
--- a/src/sections/target/Safety/SafetyTables.js
+++ b/src/sections/target/Safety/SafetyTables.js
@@ -1,17 +1,9 @@
 import React from 'react';
 import _ from 'lodash';
-import { Typography, Divider, Box, makeStyles } from '@material-ui/core';
+import { Typography, Divider, Box } from '@material-ui/core';
 
 import Link from '../../../components/Link';
 import DataTable from '../../../components/Table/DataTable';
-
-const useStyles = makeStyles(theme => ({
-  tooltip: {
-    backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.grey[300]}`,
-    color: theme.palette.text.primary,
-  },
-}));
 
 const SafetyTables = ({ symbol, data }) => {
   const { adverseEffects, safetyRiskInfo, tox21, etox } = data;

--- a/src/sections/target/Safety/SafetyTables.js
+++ b/src/sections/target/Safety/SafetyTables.js
@@ -244,9 +244,7 @@ const ReferencesCell = ({ children }) => {
       return (
         <React.Fragment key={`${refLabel}:${pubUrl}`}>
           <Link external to={isHecatos ? heCaTosUrl : pubUrl}>
-            <span>
-              {refLabel || (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
-            </span>
+            {refLabel || (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
           </Link>{' '}
         </React.Fragment>
       );

--- a/src/sections/target/Safety/SafetyTables.js
+++ b/src/sections/target/Safety/SafetyTables.js
@@ -250,29 +250,17 @@ const etoxColumns = [
 ];
 
 const ReferencesCell = ({ children }) => {
-  const classes = useStyles();
-
   return children
     .filter(reference => reference.pubmedId || reference.refLink)
     .map(({ pubUrl, refLabel, pubmedId }) => {
       const isHecatos = pubUrl.indexOf('hecatos') !== -1;
+      const heCaTosUrl = 'https://cordis.europa.eu/project/id/602156/reporting';
       return (
         <React.Fragment key={`${refLabel}:${pubUrl}`}>
-          <Link external to={pubUrl}>
-            <Tooltip
-              classes={{ tooltip: classes.tooltip }}
-              title={
-                isHecatos
-                  ? "HeCaToS Deliverable D01.5 (2015) funded by 'EU 7th Framework Programme (HEALTH-F4-2013-602156)'."
-                  : ''
-              }
-              placement="top"
-            >
-              <span>
-                {refLabel ||
-                  (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
-              </span>
-            </Tooltip>
+          <Link external to={isHecatos ? heCaTosUrl : pubUrl}>
+            <span>
+              {refLabel || (pubmedId ? `Pubmed ID: ${pubmedId}` : '(no name)')}
+            </span>
           </Link>{' '}
         </React.Fragment>
       );

--- a/src/sections/target/Safety/SafetyTables.js
+++ b/src/sections/target/Safety/SafetyTables.js
@@ -1,12 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import {
-  Typography,
-  Divider,
-  Box,
-  Tooltip,
-  makeStyles,
-} from '@material-ui/core';
+import { Typography, Divider, Box, makeStyles } from '@material-ui/core';
 
 import Link from '../../../components/Link';
 import DataTable from '../../../components/Table/DataTable';


### PR DESCRIPTION
In the Safety widget, remove the tooltip and update the url for the HeCaTos link; fixes issue https://github.com/opentargets/platform/issues/1566