### PR TITLE
Fix Known Drugs reference labels and links

### DIFF
--- a/src/sections/common/KnownDrugs/SourceDrawer.js
+++ b/src/sections/common/KnownDrugs/SourceDrawer.js
@@ -71,12 +71,10 @@ const sourceDrawerStyles = makeStyles(theme => ({
 
 const tableSourceLabel = name =>
   ({
-    'ATC Information': 'ATC',
-    'Clinical Trials Information': 'ClinicalTrials.gov',
+    ATC: 'ATC',
     ClinicalTrials: 'ClinicalTrials.gov',
-    'DailyMed Information': 'DailyMed',
     DailyMed: 'DailyMed',
-    'FDA Information': 'FDA',
+    FDA: 'FDA',
   }[name]);
 
 const drawerSourceLabel = (name, url) => {
@@ -86,10 +84,12 @@ const drawerSourceLabel = (name, url) => {
   if (name === 'DailyMed') {
     return url.split('setid=')[1] || `${tableSourceLabel(name)} reference`;
   }
-  if (name === 'FDA Information') {
+  if (name === 'FDA') {
     return url.split('set_id:')[1] || `${tableSourceLabel(name)} reference`;
   }
-
+  if (name === 'ATC') {
+    return url.split('code=')[1] || `${tableSourceLabel(name)} reference`;
+  }
   return `${url.name} entry`;
 };
 


### PR DESCRIPTION
This PR makes an additional fix to the Known Drugs references drawer - see opentargets/platform#1568.

The `tableSourceLabel` and `drawerSourceLabel` have been updated as the word "information" has been dropped due to an upstream change. This fix ensures that ClinicalTrials.gov, FDA, DailyMed, and ATC records are correctly displayed. For an example, see ACETAMINOPHEN - CHEMBL112 and in the Clinical Precedence table, look at the row with 528 references for Phase IV - N/A for pain.

![Screenshot 2021-06-16 at 16 03 40](https://user-images.githubusercontent.com/7490258/122244133-8a09be80-cebc-11eb-8e66-7157bfd14307.png)