### PR TITLE
Add release version to homepage

### DIFF
--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -24,6 +24,7 @@ import NavBar from '../../components/NavBar';
 import Search from '../../components/Search';
 import searchExamples from './searchExamples';
 import Splash from './Splash';
+import Version from './Version';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -159,6 +160,7 @@ const HomePage = () => {
               <Link to={`/drug/${drugs[1].id}`}>{drugs[1].label}</Link>
             </Hidden>
           </Grid>
+          <Version />
         </HomeBox>
 
         {/* scroll down button */}

--- a/src/pages/HomePage/Version.js
+++ b/src/pages/HomePage/Version.js
@@ -1,0 +1,69 @@
+import { gql, useQuery } from '@apollo/client';
+import { Box } from '@material-ui/core';
+import Link from '../../components/Link';
+
+// HELPERS
+function getVersion({ month, year }) {
+  return `${year}.${month < 10 ? '0' : ''}${month}`;
+}
+
+function getFullMonth({ month, year }) {
+  const date = new Date(year + 2000, month - 1);
+  return date.toLocaleString('default', { month: 'long' });
+}
+
+// QUERY
+const DATA_VERSION_QUERY = gql`
+  query DataVersion {
+    meta {
+      dataVersion {
+        month
+        year
+      }
+    }
+  }
+`;
+
+// CONTAINER
+function VersionContainer({ children }) {
+  return (
+    <Box display="flex" mt={5} justifyContent="center" alignContent="center">
+      {children}
+    </Box>
+  );
+}
+
+// LINK
+function VersionLink({ month, year, version }) {
+  return (
+    <Box ml={1}>
+      <Link external to="https://platform-docs.opentargets.org/release-notes">
+        {month} 20{year} ({version})
+      </Link>
+    </Box>
+  );
+}
+
+// MAIN COMPONENT
+function Version() {
+  const { data, loading, error } = useQuery(DATA_VERSION_QUERY);
+  if (error) return null;
+  if (loading)
+    return <VersionContainer>Loading data version ...</VersionContainer>;
+  const {
+    meta: {
+      dataVersion: { month, year },
+    },
+  } = data;
+  const version = getVersion({ month, year });
+  const fullMonth = getFullMonth({ month, year });
+
+  return (
+    <VersionContainer>
+      Last update:
+      <VersionLink month={fullMonth} year={year} version={version} />
+    </VersionContainer>
+  );
+}
+
+export default Version;


### PR DESCRIPTION
https://github.com/opentargets/platform/issues/1609 Version added to home page box.

<img width="1257" alt="Screen Shot 2021-06-21 at 8 41 05 AM" src="https://user-images.githubusercontent.com/2972633/122780828-71a6f480-d26c-11eb-8d00-63b67e0bc597.png">
