### PR TITLE
Standardize CT Phase format

### DIFF
--- a/src/sections/common/KnownDrugs/Body.js
+++ b/src/sections/common/KnownDrugs/Body.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import client from '../../../client';
 import Link from '../../../components/Link';
-import { naLabel } from '../../../constants';
+import { naLabel, phaseMap } from '../../../constants';
 import { sentenceCase } from '../../../utils/global';
 import SectionItem from '../../../components/Section/SectionItem';
 import SourceDrawer from './SourceDrawer';
@@ -16,6 +16,10 @@ function getColumnPool(id, entity) {
       columns: [
         {
           id: 'phase',
+          label: 'Phase',
+          sortable: true,
+          renderCell: ({ phase }) => phaseMap[phase],
+          filterValue: ({ phase }) => phaseMap[phase],
         },
         {
           id: 'status',

--- a/src/sections/drug/Indications/Body.js
+++ b/src/sections/drug/Indications/Body.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
-import { sourceMap } from '../../../constants';
+import { sourceMap, phaseMap } from '../../../constants';
 import { referenceUrls } from '../../../utils/urls';
 import {
   DataTable,
@@ -41,6 +41,8 @@ const columns = [
     label: 'Max Phase',
     sortable: true,
     width: '10%',
+    renderCell: ({ maxPhaseForIndication }) => phaseMap[maxPhaseForIndication],
+    filterValue: ({ maxPhaseForIndication }) => phaseMap[maxPhaseForIndication],
   },
   {
     id: 'references',


### PR DESCRIPTION
https://github.com/opentargets/platform/issues/1569

- [x] In the Known Drugs table for a particular disease - Column Phase
- [ ] ~In the description of a particular drug - Field Max Phase~
- [x] In the Indications table for a particular drug - Column Max Phase
- [x] In the Clinical Precedence table for a particular drug - Column Phase

Drug description can't be standardized by now because the full response comes from the backend.