### PR TITLE
OT Genetics table - Hide "N/A" if variantRsid is null

### DIFF
--- a/src/sections/evidence/OTGenetics/Body.js
+++ b/src/sections/evidence/OTGenetics/Body.js
@@ -80,9 +80,7 @@ const columns = [
             </Link>
             )
           </Typography>
-        ) : (
-          naLabel
-        )}
+        ) : null}
       </>
     ),
     filterValue: ({ variantId, variantRsId }) => `${variantId} ${variantRsId}`,


### PR DESCRIPTION
https://github.com/opentargets/platform/issues/1621

Hide "N/A" if variantRsid is null

