### PR TITLE
Add ellipsis wrapper to column field

### DIFF
--- a/src/sections/evidence/Reactome/Body.js
+++ b/src/sections/evidence/Reactome/Body.js
@@ -126,7 +126,7 @@ const columns = [
           }))}
         />
       ) : variantAminoacidDescriptions?.length === 1 ? (
-        variantAminoacidDescriptions[0]
+        <EllsWrapper>{variantAminoacidDescriptions[0]}</EllsWrapper>
       ) : (
         naLabel
       );


### PR DESCRIPTION
Add ellipsis wrapper component to table column to stop field from overlapping next column. Fix issue https://github.com/opentargets/platform/issues/1631