### PR TITLE
Add configuration for helpdesk email

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Typography } from '@material-ui/core';
+import config from '../config';
 
 class ErrorBoundary extends Component {
   state = {
@@ -12,7 +13,9 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = 'Something went wrong. Please contact Open Targets at support@targetvalidation.org',
+      message = `Something went wrong. Please contact Open Targets at ${
+        config.helpdeskEmail
+      }`,
     } = this.props;
 
     return this.state.hasError ? (

--- a/src/config.js
+++ b/src/config.js
@@ -11,9 +11,8 @@ const config = {
     window.configEFOURL ??
     'https://storage.googleapis.com/open-targets-data-releases/alpha-rewrite/static/ontology/diseases_efo.jsonl',
   primaryColor: window.configPrimaryColor ?? '#3489ca',
-  flagShowOTARProjects:
-    window.configFlagShowOTARProjects ??
-    false
+  flagShowOTARProjects: window.configFlagShowOTARProjects ?? false,
+  helpdeskEmail: window.configHelpdeskEmail ?? 'helpdesk@opentargets.org',
 };
 
 export default config;

--- a/src/constants.js
+++ b/src/constants.js
@@ -54,9 +54,9 @@ export const externalLinks = {
       url: 'https://platform-docs.opentargets.org',
     },
     {
-      label: 'helpdesk@opentargets.org',
+      label: config.helpdeskEmail,
       icon: faEnvelope,
-      url: 'mailto:helpdesk@opentargets.org',
+      url: `mailto:${config.helpdeskEmail}`,
     },
   ],
   social: [
@@ -97,7 +97,7 @@ export const mainMenuItems = [
   // Contact
   {
     name: 'Contact us',
-    url: 'mailto:helpdesk@opentargets.org',
+    url: `mailto:${config.helpdeskEmail}`,
     external: true,
   },
 ];


### PR DESCRIPTION
Extract helpdesk email address to config and update in error pages, menu and footer.
Fixes issues https://github.com/opentargets/platform/issues/1646 and https://github.com/opentargets/platform/issues/1649