### PR TITLE
Target - Parse new list of descriptions with links

### DIFF
--- a/src/pages/TargetPage/ProfileHeader.js
+++ b/src/pages/TargetPage/ProfileHeader.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { loader } from 'graphql.macro';
-
+import TargetDescription from './TargetDescription';
 import {
-  Description,
   ProfileHeader as BaseProfileHeader,
   ChipList,
 } from '../../components/ProfileHeader';
@@ -55,18 +54,39 @@ const parseSynonyms = synonyms => {
   return parsedSynonyms;
 };
 
+// TODO: Replace this with PublicationsDrawer component
+function makePmidLink(match) {
+  const id = match.substring(7);
+  const linkStyles =
+    'color: #3489ca; font-size: inherit; text-decoration: none;';
+  return `PubMed:<a style="${linkStyles}" href="https://europepmc.org/abstract/med/${id}" target="_blank">${id}</a>`;
+}
+
+function clearCodes(descriptions) {
+  if (!descriptions) return [];
+  return descriptions.map(desc => {
+    const codeStart = desc.indexOf('{');
+    const parsedDesc = desc.slice(0, codeStart);
+    return parsedDesc.replace(/Pubmed:\d+/gi, makePmidLink);
+  });
+}
+
 function ProfileHeader() {
   const { loading, error, data } = usePlatformApi();
 
   //TODO: Errors!
   if (error) return null;
 
-  const description = data?.target.functionDescriptions?.[0];
+  const targetDescription = clearCodes(data?.target.functionDescriptions);
   const synonyms = parseSynonyms(data?.target.synonyms || []);
 
   return (
     <BaseProfileHeader>
-      <Description loading={loading}>{description}</Description>
+      <TargetDescription
+        loading={loading}
+        descriptions={targetDescription}
+        targetId={data?.target.id}
+      />
       <ChipList title="Synonyms" loading={loading}>
         {synonyms}
       </ChipList>

--- a/src/pages/TargetPage/TargetDescription.js
+++ b/src/pages/TargetPage/TargetDescription.js
@@ -1,0 +1,112 @@
+import React, { useState, useLayoutEffect, useRef } from 'react';
+import { Typography, withStyles } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+
+const styles = theme => ({
+  textContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    '& span:not(:last-child)': { marginBottom: '12px' },
+  },
+  showMore: {
+    color: theme.palette.primary.main,
+    cursor: 'pointer',
+  },
+});
+
+const LongText = ({
+  classes,
+  lineLimit,
+  children,
+  variant = 'body2',
+  descriptions,
+  targetId,
+}) => {
+  const containerRef = useRef();
+  const [showMore, setShowMore] = useState(false);
+  const [numberOfLines, setNumberOfLines] = useState();
+
+  useLayoutEffect(
+    () => {
+      const container = containerRef.current;
+      const el = containerRef.current;
+      const height = el.offsetHeight;
+      const lineHeight = Number.parseInt(
+        document.defaultView
+          .getComputedStyle(el, null)
+          .getPropertyValue('line-height'),
+        10
+      );
+      const numberOfLines = Math.round(height / lineHeight);
+
+      container.style.height =
+        numberOfLines <= lineLimit
+          ? 'auto'
+          : showMore
+          ? 'auto'
+          : `${lineLimit * lineHeight}px`;
+
+      setNumberOfLines(numberOfLines);
+    },
+    [lineLimit, showMore, children]
+  );
+
+  function createDescriptionMarkup(desc) {
+    return { __html: desc };
+  }
+
+  return (
+    <Typography variant={variant}>
+      <span ref={containerRef} className={classes.textContainer}>
+        {descriptions.map((desc, i) => (
+          <span
+            key={`${targetId}-${i}`}
+            dangerouslySetInnerHTML={createDescriptionMarkup(desc)}
+          />
+        ))}
+      </span>
+      {numberOfLines >= lineLimit && (
+        <span>
+          {showMore ? '' : '... '}[{' '}
+          <span
+            className={classes.showMore}
+            onClick={() => setShowMore(!showMore)}
+          >
+            {showMore ? ' hide' : ' show more'}
+          </span>{' '}
+          ]
+        </span>
+      )}
+    </Typography>
+  );
+};
+
+const StyledLongText = withStyles(styles)(LongText);
+
+function TargetDescription({ descriptions, loading = false, targetId }) {
+  let content;
+
+  if (!descriptions || descriptions.length < 1) {
+    content = 'No description available';
+  } else {
+    content = (
+      <>
+        <StyledLongText
+          lineLimit={3}
+          descriptions={descriptions}
+          targetId={targetId}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="subtitle2">Description</Typography>
+      {loading ? <Skeleton /> : content}
+    </>
+  );
+}
+
+export default TargetDescription;


### PR DESCRIPTION
This PR refers to both of these tickets:
- https://github.com/opentargets/platform/issues/1697
- https://github.com/opentargets/platform/issues/1696

@andrewhercules for the PubMed links in the description it is complex to add the Publication Drawer component now. I'll need to review that implementation with @mirandaio. For the purpose of the task, I implemented simple `<a>` tags

