### PR TITLE
KnownDrugs downloads - Include drug name, disease/phenotype name, and approved symbol

### DIFF
--- a/src/sections/common/KnownDrugs/Body.js
+++ b/src/sections/common/KnownDrugs/Body.js
@@ -137,6 +137,7 @@ function Body({
   Description,
   columnsToShow,
   stickyColumn,
+  exportColumns,
 }) {
   const [initialLoading, setInitialLoading] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -203,7 +204,7 @@ function Body({
 
   const getWholeDataset = useCursorBatchDownloader(
     BODY_QUERY,
-    variables,
+    (variables = { ...variables, freeTextQuery: globalFilter }),
     `data[${entity}].knownDrugs`
   );
 
@@ -253,8 +254,6 @@ function Body({
     });
   };
 
-  // const id = variables[Object.keys(variables)[0]];
-
   return (
     <SectionItem
       definition={definition}
@@ -279,6 +278,7 @@ function Body({
           onGlobalFilterChange={handleGlobalFilterChange}
           onPageChange={handlePageChange}
           onRowsPerPageChange={handleRowsPerPageChange}
+          dataDownloaderColumns={exportColumns}
         />
       )}
     />

--- a/src/sections/common/KnownDrugs/Body.js
+++ b/src/sections/common/KnownDrugs/Body.js
@@ -204,7 +204,7 @@ function Body({
 
   const getWholeDataset = useCursorBatchDownloader(
     BODY_QUERY,
-    (variables = { ...variables, freeTextQuery: globalFilter }),
+    { ...variables, freeTextQuery: globalFilter },
     `data[${entity}].knownDrugs`
   );
 

--- a/src/sections/disease/KnownDrugs/Body.js
+++ b/src/sections/disease/KnownDrugs/Body.js
@@ -3,8 +3,72 @@ import { loader } from 'graphql.macro';
 
 import { Body as KnownDrugsBody } from '../../common/KnownDrugs';
 import Description from './Description';
+import { sentenceCase } from '../../../utils/global';
 
 const KNOWN_DRUGS_BODY_QUERY = loader('./KnownDrugsQuery.gql');
+
+const exportColumns = () => [
+  {
+    label: 'diseaseId',
+    exportValue: row => row.disease.id,
+  },
+  {
+    label: 'diseaseName',
+    exportValue: row => row.disease.name,
+  },
+  {
+    label: 'drugId',
+    exportValue: row => row.drug.id,
+  },
+  {
+    label: 'drugName',
+    exportValue: row => row.drug.name,
+  },
+  {
+    label: 'type',
+    exportValue: row => row.drugType,
+  },
+  {
+    label: 'mechanismOfAction',
+    exportValue: row => row.mechanismOfAction,
+  },
+  {
+    label: 'actionType',
+    exportValue: ({ drug: { mechanismsOfAction }, target }) => {
+      if (!mechanismsOfAction) return '';
+      const at = new Set();
+      mechanismsOfAction.rows.forEach(row => {
+        row.targets.forEach(t => {
+          if (t.id === target.id) {
+            at.add(row.actionType);
+          }
+        });
+      });
+      const actionTypes = Array.from(at);
+      return actionTypes.map(actionType => sentenceCase(actionType));
+    },
+  },
+  {
+    label: 'symbol',
+    exportValue: row => row.target.approvedSymbol,
+  },
+  {
+    label: 'name',
+    exportValue: row => row.target.approvedName,
+  },
+  {
+    label: 'phase',
+    exportValue: row => row.phase,
+  },
+  {
+    label: 'status',
+    exportValue: row => row.status,
+  },
+  {
+    label: 'source',
+    exportValue: row => row.urls.map(reference => reference.url),
+  },
+];
 
 function Body({ definition, id: efoId, label: name }) {
   return (
@@ -16,6 +80,7 @@ function Body({ definition, id: efoId, label: name }) {
       Description={() => <Description name={name} />}
       columnsToShow={['disease', 'drug', 'target', 'clinicalTrials']}
       stickyColumn="drug"
+      exportColumns={exportColumns(efoId)}
     />
   );
 }

--- a/src/sections/disease/KnownDrugs/Body.js
+++ b/src/sections/disease/KnownDrugs/Body.js
@@ -7,7 +7,7 @@ import { sentenceCase } from '../../../utils/global';
 
 const KNOWN_DRUGS_BODY_QUERY = loader('./KnownDrugsQuery.gql');
 
-const exportColumns = () => [
+const exportColumns = [
   {
     label: 'diseaseId',
     exportValue: row => row.disease.id,
@@ -80,7 +80,7 @@ function Body({ definition, id: efoId, label: name }) {
       Description={() => <Description name={name} />}
       columnsToShow={['disease', 'drug', 'target', 'clinicalTrials']}
       stickyColumn="drug"
-      exportColumns={exportColumns(efoId)}
+      exportColumns={exportColumns}
     />
   );
 }

--- a/src/sections/drug/KnownDrugs/Body.js
+++ b/src/sections/drug/KnownDrugs/Body.js
@@ -6,6 +6,37 @@ import Description from './Description';
 
 const KNOWN_DRUGS_BODY_QUERY = loader('./KnownDrugsQuery.gql');
 
+const exportColumns = [
+  {
+    label: 'diseaseId',
+    exportValue: row => row.disease.id,
+  },
+  {
+    label: 'diseaseName',
+    exportValue: row => row.disease.name,
+  },
+  {
+    label: 'symbol',
+    exportValue: row => row.target.approvedSymbol,
+  },
+  {
+    label: 'name',
+    exportValue: row => row.target.approvedName,
+  },
+  {
+    label: 'phase',
+    exportValue: row => row.phase,
+  },
+  {
+    label: 'status',
+    exportValue: row => row.status,
+  },
+  {
+    label: 'source',
+    exportValue: row => row.urls.map(reference => reference.url),
+  },
+];
+
 function Body({ definition, id: chemblId, label: name }) {
   return (
     <KnownDrugsBody
@@ -16,6 +47,7 @@ function Body({ definition, id: chemblId, label: name }) {
       Description={() => <Description name={name} />}
       columnsToShow={['disease', 'target', 'clinicalTrials']}
       stickyColumn="disease"
+      exportColumns={exportColumns}
     />
   );
 }

--- a/src/sections/target/KnownDrugs/Body.js
+++ b/src/sections/target/KnownDrugs/Body.js
@@ -3,8 +3,64 @@ import { loader } from 'graphql.macro';
 
 import { Body as KnownDrugsBody } from '../../common/KnownDrugs';
 import Description from './Description';
+import { sentenceCase } from '../../../utils/global';
 
 const KNOWN_DRUGS_BODY_QUERY = loader('./KnownDrugsQuery.gql');
+
+const exportColumns = id => [
+  {
+    label: 'drugId',
+    exportValue: row => row.drug.id,
+  },
+  {
+    label: 'drugName',
+    exportValue: row => row.drug.name,
+  },
+  {
+    label: 'type',
+    exportValue: row => row.drugType,
+  },
+  {
+    label: 'mechanismOfAction',
+    exportValue: row => row.mechanismOfAction,
+  },
+  {
+    label: 'actionType',
+    exportValue: ({ drug: { mechanismsOfAction } }) => {
+      if (!mechanismsOfAction) return '';
+      const at = new Set();
+      mechanismsOfAction.rows.forEach(row => {
+        row.targets.forEach(t => {
+          if (t.id === id) {
+            at.add(row.actionType);
+          }
+        });
+      });
+      const actionTypes = Array.from(at);
+      return actionTypes.map(actionType => sentenceCase(actionType));
+    },
+  },
+  {
+    label: 'diseaseId',
+    exportValue: row => row.disease.id,
+  },
+  {
+    label: 'diseaseName',
+    exportValue: row => row.disease.name,
+  },
+  {
+    label: 'phase',
+    exportValue: row => row.phase,
+  },
+  {
+    label: 'status',
+    exportValue: row => row.status,
+  },
+  {
+    label: 'source',
+    exportValue: row => row.urls.map(reference => reference.url),
+  },
+];
 
 function Body({ definition, id: ensgId, label: symbol }) {
   return (
@@ -16,6 +72,7 @@ function Body({ definition, id: ensgId, label: symbol }) {
       Description={() => <Description symbol={symbol} />}
       columnsToShow={['drug', 'disease', 'clinicalTrials']}
       stickyColumn="drug"
+      exportColumns={exportColumns(ensgId)}
     />
   );
 }


### PR DESCRIPTION
This PR adds the fields requested here https://github.com/opentargets/platform/issues/1647 for the exported KnownDrugs table.

It also fixes the KnonDrugs data table download when server-side filtering for target, disease and drug (reference https://github.com/opentargets/platform/issues/1613)