### PR TITLE
Bibliography - [bug] Abstract keeps open on page change

### DIFF
--- a/src/components/PublicationsDrawer/PublicationWrapper.js
+++ b/src/components/PublicationsDrawer/PublicationWrapper.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   faPlusCircle,
   faMinusCircle,
@@ -52,6 +52,13 @@ function PublicationWrapper({
   const handleShowAbstractClick = () => {
     setShowAbstract(showAbstract => !showAbstract);
   };
+
+  useEffect(
+    () => {
+      setShowAbstract(false);
+    },
+    [europePmcId]
+  );
 
   const classes = useStyles();
 

--- a/src/sections/common/Literature/Body.js
+++ b/src/sections/common/Literature/Body.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, lazy } from 'react';
+import React, { useEffect } from 'react';
 import PublicationsList from './PublicationsList';
 import { makeStyles, Box } from '@material-ui/core';
 import Description from './Description';
@@ -12,7 +12,6 @@ import {
 import Entities from './Entities';
 import Category from './Category';
 import CountInfo from './CountInfo';
-const TimeTravelObserver = lazy(() => import('./TimeTravelObserver'));
 
 const useStyles = makeStyles(() => ({
   controlsContainer: {
@@ -68,11 +67,6 @@ function LiteratureList({ id, name, entity, BODY_QUERY }) {
       <Box className={classes.controlsContainer}>
         <Category />
         <CountInfo />
-        <Suspense fallback={<div>Loading debug tool...</div>}>
-          {process.env.NODE_ENV === 'development' ? (
-            <TimeTravelObserver />
-          ) : null}
-        </Suspense>
       </Box>
       <Entities id={id} name={name} />
       <PublicationsList hideSearch handleRowsPerPageChange={() => {}} />


### PR DESCRIPTION
This PR is to fix the `showAbstract` state on page change in the bibliography component. https://github.com/opentargets/platform/issues/1655

It also removes the TimeTravel development component from the dev environment because of the annoying warnings. Refactor pending.