### PR TITLE
Handle null literature in reactome evidence

### DIFF
--- a/src/sections/evidence/Reactome/Body.js
+++ b/src/sections/evidence/Reactome/Body.js
@@ -138,7 +138,7 @@ const columns = [
     label: 'Literature',
     renderCell: ({ literature = [] }) => {
       const literatureList = [];
-      literature.forEach(id => {
+      literature?.forEach(id => {
         if (id !== 'NA') {
           literatureList.push({
             name: id,


### PR DESCRIPTION
Simple fix for `null` literature object in the Reactome evidence widget.
Odd as we already set literature to a default empty array - I believe that is being ignored because it would otherwise change the data object coming into the render function.