### PR TITLE
Add option to open external link in new tab

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -40,10 +40,14 @@ class Link extends React.Component {
       to,
       onClick,
       external,
+      newTab,
       footer,
       tooltip,
       className,
     } = this.props;
+    const newTabProps = newTab
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {};
     return external ? (
       <a
         className={classNames(
@@ -57,6 +61,7 @@ class Link extends React.Component {
         )}
         href={to}
         onClick={onClick}
+        {...newTabProps}
       >
         {children}
       </a>


### PR DESCRIPTION
Hi,

This is a pretty straightforward PR. We sometimes find it useful to open a link to an external resource in a new tab rather than the current tab. With the proposed change, one can do so by adding `newTab` to the `<Link>` component props:

```js
<Link to={url} external newTab>Label</Link>
```

Please let me know what you think. I hope you find this useful.

Cheers,
Roman