### PR TITLE
Adjust space for Y axis labels in GTEx expression based on data

### DIFF
--- a/src/sections/target/Expression/GtexVariability.js
+++ b/src/sections/target/Expression/GtexVariability.js
@@ -17,6 +17,23 @@ const boxPadding = boxHeight / 4;
 const margin = { top: 40, right: 20, bottom: 20, left: 220 };
 const outlierRadius = 2;
 
+function getTextWidth(text, fontSize, fontFace) {
+  const canvas = document.createElement('canvas'),
+    context = canvas.getContext('2d');
+  context.font = `${fontSize}px ${fontFace}`;
+  return context.measureText(text).width;
+}
+
+function getLongestId(data) {
+  let longestId = '';
+  data.forEach(d => {
+    if (d.tissueSiteDetailId.length > longestId.length) {
+      longestId = d.tissueSiteDetailId;
+    }
+  });
+  return longestId;
+}
+
 function buildTooltip(X, tooltipObject, data) {
   return Object.keys(tooltipObject)
     .map(field => {
@@ -46,6 +63,7 @@ class GtexVariability extends Component {
 
   render() {
     const { theme, data } = this.props;
+    margin['left'] = getTextWidth(getLongestId(data), 12, 'Arial');
 
     const height = data.length * boxHeight + margin.top + margin.bottom;
 


### PR DESCRIPTION
Hi,

This PR contains a small code change that enables automatic adjustment of the left margin in the GTEx expression plot according to the available labels. A new function (based on https://stackoverflow.com/a/35373030) is used to estimate the size of the longest label.

Here are some screenshots for comparison:

1. Reference (no changes made)
<img width="642" alt="Screenshot 2021-11-04 at 16 11 34" src="https://user-images.githubusercontent.com/18103560/140349120-cd071112-06e4-481d-992f-29c7db288be3.png">
2. Proposed code change with same data
<img width="631" alt="Screenshot 2021-11-04 at 16 13 14" src="https://user-images.githubusercontent.com/18103560/140349759-c7b2797d-e687-4562-bf51-49a0f3f397c7.png">
3. Artificially long label is cropped without proposed code change
<img width="631" alt="Screenshot 2021-11-04 at 16 15 05" src="https://user-images.githubusercontent.com/18103560/140350499-8131cb83-4cf0-49d8-8b12-5d4df1aa6299.png">
4. Artificially long label with proposed code change
<img width="634" alt="Screenshot 2021-11-04 at 16 14 50" src="https://user-images.githubusercontent.com/18103560/140350938-95e602ff-a3a5-41e7-a927-740c88ce1a3a.png">

Please let me know what you think. I hope you find this useful.

Cheers,
Roman