### PR TITLE
Show tooltip with additional info in GTEx expression plot

### DIFF
--- a/src/sections/target/Expression/GtexVariability.js
+++ b/src/sections/target/Expression/GtexVariability.js
@@ -17,8 +17,25 @@ const boxPadding = boxHeight / 4;
 const margin = { top: 40, right: 20, bottom: 20, left: 220 };
 const outlierRadius = 2;
 
+function buildTooltip(X, tooltipObject, data) {
+  return Object.keys(tooltipObject)
+    .map(field => {
+      const value =
+        data[field] === null
+          ? 'N/A'
+          : data[field].toFixed(tooltipObject[field]['roundDigits']);
+      return (
+        `<tspan x='${X}' dy='1.2em' style="font-weight: bold;">` +
+        `${tooltipObject[field]['label']}: </tspan>` +
+        `<tspan>${value}</tspan>`
+      );
+    })
+    .join('');
+}
+
 class GtexVariability extends Component {
   boxPlotRef = React.createRef();
+  tooltipRef = React.createRef();
   xAxisRef = React.createRef();
   yAxisRef = React.createRef();
   xAxis = axisTop();
@@ -55,6 +72,10 @@ class GtexVariability extends Component {
           ref={this.yAxisRef}
           transform={`translate(${margin.left}, ${margin.top})`}
         />
+        <g
+          ref={this.tooltipRef}
+          transform={`translate(${margin.left}, ${margin.top})`}
+        />
       </svg>
     );
   }
@@ -86,6 +107,51 @@ class GtexVariability extends Component {
 
     colour.domain(data.map(d => d.tissueSiteDetailId)).range(schemeCategory10);
 
+    const tooltipTextFields = {
+      lowerLimit: {
+        label: 'lower limit',
+        roundDigits: 1,
+      },
+      q1: {
+        label: 'q1',
+        roundDigits: 1,
+      },
+      median: {
+        label: 'median',
+        roundDigits: 1,
+      },
+      q3: {
+        label: 'q3',
+        roundDigits: 1,
+      },
+      upperLimit: {
+        label: 'upper limit',
+        roundDigits: 1,
+      },
+    };
+
+    const tooltipSettings = {
+      fontSize: 12,
+      fontFamily: 'sans-serif',
+      offsetText: 5,
+      offsetX: 10,
+      offsetY: boxHeight / 2 + 5,
+    };
+
+    const tooltip = select(this.tooltipRef.current);
+
+    const tooltipRect = tooltip
+      .append('rect')
+      .style('fill', 'white')
+      .style('opacity', 0.8)
+      .style('visibility', 'hidden');
+
+    const tooltipText = tooltip
+      .append('text')
+      .style('font-family', tooltipSettings['fontFamily'])
+      .style('font-size', `${tooltipSettings['fontSize']}px`)
+      .style('visibility', 'hidden');
+
     const boxPlot = select(this.boxPlotRef.current);
 
     const boxContainer = boxPlot
@@ -110,7 +176,61 @@ class GtexVariability extends Component {
       )
       .attr('width', d => x(d.q3) - x(d.q1))
       .attr('height', rectHeight)
-      .attr('fill', d => colour(d.tissueSiteDetailId));
+      .attr('fill', d => colour(d.tissueSiteDetailId))
+      .on('mouseover', function(d) {
+        var X =
+          parseFloat(select(this).attr('x')) +
+          parseFloat(select(this).attr('width')) +
+          tooltipSettings['offsetX'];
+        var Y = parseFloat(select(this).attr('y')) + tooltipSettings['offsetY'];
+
+        tooltipText
+          .attr('y', Y)
+          .html(
+            buildTooltip(
+              X + tooltipSettings['offsetText'],
+              tooltipTextFields,
+              d
+            )
+          )
+          .style('visibility', 'visible');
+
+        const bbox = tooltip
+          .select('text')
+          .node()
+          .getBBox();
+
+        // keep tooltip box within SVG (X axis)
+        if (margin.left + X + bbox.width + margin.right > width) {
+          X = width - margin.right - bbox.width - margin.left;
+          // re-build tooltip string; this is necessary because the X coordinate
+          // is part of the tooltip string
+          tooltipText.html(
+            buildTooltip(
+              X + tooltipSettings['offsetText'],
+              tooltipTextFields,
+              d
+            )
+          );
+        }
+
+        // keep tooltip box within SVG (Y axis)
+        if (margin.top + Y + bbox.height + margin.bottom > height) {
+          Y = height - margin.top - bbox.height - margin.bottom;
+          tooltipText.attr('y', Y);
+        }
+
+        tooltipRect
+          .attr('x', X)
+          .attr('y', Y)
+          .attr('width', bbox.width + 10)
+          .attr('height', bbox.height + 10)
+          .style('visibility', 'visible');
+      })
+      .on('mouseout', function() {
+        tooltipRect.style('visibility', 'hidden');
+        tooltipText.style('visibility', 'hidden');
+      });
 
     boxContainer
       .append('line')


### PR DESCRIPTION
Hi,

This PR adds a tooltip to the GTEx expression plot, shown when hovering over the rectangle drawn between q1 and q3. The tooltip box is shown underneath the hovered row, starting at q3. The box width automatically adjusts to the text width. A partially transparent background improves visibility when the box is on top of other data. When the tooltip box would extend over the canvas (right or bottom edge), its respective X/Y position is adjusted to make sure the box is completely within the canvas (see screenshot 2 & 3).

1. Hovering the second row
![Screenshot 2021-11-05 at 12 58 35](https://user-images.githubusercontent.com/18103560/140513906-e4cfdf5e-c3e3-4e04-aac4-3c1b715aab15.png)
2. Hovering the first row (tooltip would extend over right canvas edge)
![Screenshot 2021-11-05 at 12 58 17](https://user-images.githubusercontent.com/18103560/140513899-82c8dcb6-8b1d-4c2d-b60c-b2453b315160.png)
3. Hovering the last row (tooltip would extend over bottom canvas edge)
![Screenshot 2021-11-05 at 12 58 24](https://user-images.githubusercontent.com/18103560/140513905-f3b3e148-b92e-449b-8061-a1cd149ab618.png)

Please let me know what you think. I hope you find this useful.

Cheers,
Roman