### PR TITLE
Lf fix mouse allelic

### DIFF
--- a/src/components/PublicationsDrawer/PublicationsDrawer.js
+++ b/src/components/PublicationsDrawer/PublicationsDrawer.js
@@ -172,6 +172,7 @@ function PublicationsDrawer({
   message,
   customLabel,
   caption = 'Publications',
+  singleEntryId = true,
 }) {
   const [open, setOpen] = useState(false);
   const classes = sourceDrawerStyles();
@@ -205,9 +206,11 @@ function PublicationsDrawer({
       >
         {customLabel
           ? customLabel
-          : entries.length === 1
+          : entries.length === 1 && singleEntryId
           ? entries[0].name
-          : `${entries.length} publications`}
+          : `${entries.length} ${
+              entries.length === 1 ? 'publication' : 'publications'
+            }`}
       </MUILink>
 
       <Drawer

--- a/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
+++ b/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
@@ -77,10 +77,6 @@ function AllelicCompositionDrawer({ biologicalModels }) {
     return 'N/A';
   }
 
-  if (biologicalModels.length === 1) {
-    return <Model model={biologicalModels[0]} />;
-  }
-
   return (
     <>
       <MuiLink
@@ -88,7 +84,8 @@ function AllelicCompositionDrawer({ biologicalModels }) {
         onClick={toggleOpen}
         underline="none"
       >
-        {biologicalModels.length} models
+        {biologicalModels.length}{' '}
+        {biologicalModels.length === 1 ? 'model' : 'models'}
       </MuiLink>
       <Drawer
         classes={{ root: classes.backdrop, paper: classes.container }}

--- a/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
+++ b/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
@@ -55,7 +55,11 @@ function Model({ model }) {
         />
       </Link>
       <div>
-        <PublicationsDrawer entries={entries} caption="Allelic composition" />
+        <PublicationsDrawer
+          entries={entries}
+          caption="Allelic composition"
+          singleEntryId={false}
+        />
       </div>
     </>
   );

--- a/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
+++ b/src/sections/target/MousePhenotypes/AllelicCompositionDrawer.js
@@ -55,7 +55,7 @@ function Model({ model }) {
         />
       </Link>
       <div>
-        <PublicationsDrawer entries={entries} />
+        <PublicationsDrawer entries={entries} caption="Allelic composition" />
       </div>
     </>
   );


### PR DESCRIPTION
Update the mouse phenotype table (target profile page) as per issue https://github.com/opentargets/platform/issues/1806

 - move allelic composition info from column to drawer
 - update publications drawer to allow to optionally show "1 publication" instead of pub id