### PR TITLE
Remove header efo link for otar efos on disease page

### DIFF
--- a/src/pages/DiseasePage/Header.js
+++ b/src/pages/DiseasePage/Header.js
@@ -53,7 +53,11 @@ function Header({ loading, efoId, name, dbXRefs = [] }) {
       Icon={faStethoscope}
       externalLinks={
         <>
-          <ExternalLink title="EFO" id={efoId} url={efoUrl} />
+          {efoId.startsWith('OTAR') ? (
+            <>EFO: {efoId}</>
+          ) : (
+            <ExternalLink title="EFO" id={efoId} url={efoUrl} />
+          )}
           {Object.keys(xrefs).map(xref => {
             const { label, urlStem, ids } = xrefs[xref];
             return (

--- a/src/pages/DiseasePage/Header.js
+++ b/src/pages/DiseasePage/Header.js
@@ -54,7 +54,7 @@ function Header({ loading, efoId, name, dbXRefs = [] }) {
       externalLinks={
         <>
           {efoId.startsWith('OTAR') ? (
-            <>EFO: {efoId}</>
+            `EFO: ${efoId}`
           ) : (
             <ExternalLink title="EFO" id={efoId} url={efoUrl} />
           )}


### PR DESCRIPTION
Short PR to remove the link from the EFO info in the disease page header in case of OTAR EFOs; issue https://github.com/opentargets/platform/issues/1811