### PR TITLE
Lf update safety ref link

### DIFF
--- a/src/sections/target/Safety/Safety.gql
+++ b/src/sections/target/Safety/Safety.gql
@@ -21,6 +21,7 @@ query Safety($ensemblId: String!) {
       }
       datasource
       literature
+      url
     }
   }
 }

--- a/src/sections/target/Safety/SafetyTable.js
+++ b/src/sections/target/Safety/SafetyTable.js
@@ -164,25 +164,16 @@ function getColumns(classes) {
     {
       id: 'datasource',
       label: 'Source',
-      renderCell: ({ datasource, literature }) => {
-        if (literature) {
-          return (
-            <PublicationsDrawer
-              entries={[{ name: literature }]}
-              customLabel={datasource}
-            />
-          );
-        }
-
-        return datasource === 'ToxCast' ? (
-          <Link
-            external
-            to="https://www.epa.gov/chemical-research/exploring-toxcast-data-downloadable-data"
-          >
+      renderCell: ({ datasource, literature, url }) => {
+        return literature ? (
+          <PublicationsDrawer
+            entries={[{ name: literature }]}
+            customLabel={datasource}
+          />
+        ) : (
+          <Link external to={url}>
             {datasource}
           </Link>
-        ) : (
-          datasource
         );
       },
     },


### PR DESCRIPTION
Short PR to update the source field in the target profile Safety table, as per issue https://github.com/opentargets/platform/issues/1855 .
The link is now always constructed with data from the API, simplifying the logic in the front end code.