### PR TITLE
Add header to GraphQL requests against API.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5,6 +5,7 @@ import config from './config';
 const client = new ApolloClient({
   uri: config.urlApi,
   cache: new InMemoryCache({ possibleTypes }),
+  headers: { 'OT-Platform': true },
 });
 
 export default client;


### PR DESCRIPTION
We want to improve usage telemetry of the platform. Part of this is
knowing whether requests are originating 'in-house' or from external
users interfacing with the API.

See opentargets/platform#1881