### PR TITLE
Lf fix mouse download

### DIFF
--- a/src/sections/target/MousePhenotypes/Body.js
+++ b/src/sections/target/MousePhenotypes/Body.js
@@ -25,6 +25,7 @@ function Body({ definition, id, label: symbol }) {
             mousePhenotypes={target.mousePhenotypes}
             query={MOUSE_PHENOTYPES_QUERY.loc.source.body}
             variables={variables}
+            symbol={symbol}
           />
         );
       }}

--- a/src/sections/target/MousePhenotypes/PhenotypesTable.js
+++ b/src/sections/target/MousePhenotypes/PhenotypesTable.js
@@ -69,11 +69,12 @@ const columns = [
   },
 ];
 
-function PhenotypesTable({ mousePhenotypes, query, variables }) {
+function PhenotypesTable({ mousePhenotypes, query, variables, symbol }) {
   return (
     <DataTable
       showGlobalFilter
       dataDownloader
+      dataDownloaderFileStem={`${symbol}-mouse-phenotypes`}
       columns={columns}
       rows={mousePhenotypes}
       rowsPerPageOptions={defaultRowsPerPageOptions}


### PR DESCRIPTION
Short PR to fix the target mouse phenotypes table downloads where a field displays in the drawer component as per issue https://github.com/opentargets/platform/issues/1801
 - fix Category field: use `modelPhenotypeClasses.phenotypeClass.label` field
 - fix Allelic composition: use `biologicalModels.allelicComposition` field
 - update the downloaded file name to format [target symbol]-mouse-phenotypes
 
![mouse-phenotypes-downloaded](https://user-images.githubusercontent.com/8592363/149509667-7166410d-331d-4a67-82ed-9c77d2b55a2c.png)

