### PR TITLE
Fix suggested command in error message when `REACT_APP_REVISION` missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp/platform-app/
 RUN yarn
 COPY . /tmp/platform-app/
 ARG REACT_APP_REVISION=""
-RUN : "${REACT_APP_REVISION:?Missing --build-arg REACT_APP_REVISION=\$(git rev-parse --short HEAD)}"
+RUN : "${REACT_APP_REVISION:?Missing --build-arg REACT_APP_REVISION=\$(git describe --abbrev=0)}"
 RUN yarn build
 FROM node:12
 RUN npm install -g serve


### PR DESCRIPTION
Very minor thing but I think useful for consistency (since `git describe --abbrev=0` is the way to do it [now](https://github.com/opentargets/platform-app/blob/8243eb368d7420d3a51694563c40e368cb736439/package.json#L57).