### PR TITLE
[APP]: change default API url

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@
 const config = {
   urlApi:
     window.configUrlApi ??
-    'https://api-beta-dot-open-targets-eu-dev.appspot.com/api/v4/graphql',
+    'https://api.platform.dev.opentargets.xyz/api/v4/graphql',
   googleTagManagerID: window.configGoogleTagManagerID ?? null,
   efoURL:
     window.configEFOURL ??


### PR DESCRIPTION
This is a PR to replace the current default API endpoint (remove appspot)
https://api-beta-dot-open-targets-eu-dev.appspot.com/api/v4/graphql → https://api.platform.dev.opentargets.xyz/api/v4/graphql

Deploy preview in netlify: https://deploy-preview-528--platform-app.netlify.app/