### PR TITLE
Clean up plumbing to set the git revision env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ COPY package.json yarn.lock /tmp/platform-app/
 WORKDIR /tmp/platform-app/
 RUN yarn
 COPY . /tmp/platform-app/
-ARG REACT_APP_REVISION=""
-RUN : "${REACT_APP_REVISION:?Missing --build-arg REACT_APP_REVISION=\$(git rev-parse --short HEAD)}"
 RUN yarn build
 FROM node:12
 RUN npm install -g serve

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "REACT_APP_BUILD_ID=\"$(nanoid)\" GENERATE_SOURCEMAP=false REACT_APP_REVISION=\"${REACT_APP_REVISION:-$(git describe --abbrev=0)}\" react-scripts build",
-    "build:sourcemap": "REACT_APP_BUILD_ID=\"$(nanoid)\" GENERATE_SOURCEMAP=true REACT_APP_REVISION=\"${REACT_APP_REVISION:-$(git describe --abbrev=0)}\" react-scripts build",
+    "build": "REACT_APP_BUILD_ID=\"$(nanoid)\" GENERATE_SOURCEMAP=false react-scripts build",
+    "build:sourcemap": "REACT_APP_BUILD_ID=\"$(nanoid)\" GENERATE_SOURCEMAP=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prettier": "prettier --write",

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,11 +14,6 @@ import config from './config';
 
 export const externalLinks = {
   about: [
-    // {
-    //   label: `Platform version ${process.env.REACT_APP_REVISION ?? 'dev'}`,
-    //   url: `https://github.com/opentargets/platform-app/releases/tag/${process
-    //     .env.REACT_APP_REVISION ?? 'v0.1.1'}`,
-    // },
     {
       label: 'Community forum',
       url: 'https://community.opentargets.org',


### PR DESCRIPTION
The git tag no longer appears in the footer as of 22.02 and there are no
other uses for the variable, so this can be simplified out.