### PR TITLE
Replace hard-coded email addresses with `helpdeskEmail` from config

### DIFF
--- a/src/components/PartnerLockIcon.js
+++ b/src/components/PartnerLockIcon.js
@@ -3,10 +3,13 @@ import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLock } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from './Tooltip';
+import config from '../config';
 
 const PartnerLockIcon = () => {
   return (
-    <Tooltip title="The partner preview Platform contains all data found in the public Platform along with pre-publication data from Open Targets' projects and new features developed by the Platform team. Please do not share data or screenshots outside of the consortium partners. For more information, please email helpdesk@opentargets.org.">
+    <Tooltip
+      title={`The partner preview Platform contains all data found in the public Platform along with pre-publication data from Open Targets' projects and new features developed by the Platform team. Please do not share data or screenshots outside of the consortium partners. For more information, please email ${config.profile.helpdeskEmail}.`}
+    >
       <span>
         <FontAwesomeIcon icon={faLock} />
       </span>

--- a/src/pages/EmptyPage/EmptyPage.js
+++ b/src/pages/EmptyPage/EmptyPage.js
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Link from '../../components/Link';
 import Search from '../../components/Search';
+import config from '../../config';
 
 const styles = theme => ({
   icon: {
@@ -66,7 +67,7 @@ const EmptyPage = ({ classes, children }) => {
           </Typography>
         </Grid>
         <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:helpdesk@opentargets.org">
+          <a href={`mailto:${config.profile.helpdeskEmail}`}>
             <FontAwesomeIcon
               icon={faEnvelope}
               size="3x"
@@ -78,7 +79,7 @@ const EmptyPage = ({ classes, children }) => {
           </Typography>
         </Grid>
         <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:helpdesk@opentargets.org">
+          <a href={`mailto:${config.profile.helpdeskEmail}`}>
             <FontAwesomeIcon
               icon={faSearchPlus}
               size="3x"


### PR DESCRIPTION
Unless there is a reason to keep hard-coded email addresses in some places, I suggest using the email address from the config file everywhere.